### PR TITLE
Modified PlaceNames.txt to be more machine readable

### DIFF
--- a/PlaceNames.csv
+++ b/PlaceNames.csv
@@ -1,0 +1,650 @@
+Place Name	Primary Description – Usually helps find location	Secondary Description – Often notes, sometiems helps find location	Dates
+Te Ahiaruhe	Mr. Northwood’s Sheep’s Station	Bagnall and Petersen (p. 218) show this locality (Ahieruhe) close to the site of Carterton. There is a trig point and stream of this name on the south bank of the Ruamahanga River east of the Kokotau Road Bridge	4-5 Apr 45; 19 Mar, 18 Sep 46; 12-13 Apr, 10 Nov 47; 29 May, 16 Nov 48; 29 Apr 51
+Te Ahikereru		Arrowsmith’s 1850 map shows Te Ahikereru on the west bank of the Whirinaki, slightly upstream from the junction with the Okahu stream, Bay of Plenty	30 Dec 43; 1, 5 Jan 44
+Ahuriri	Hawke’s Bay	Originally the entrance to the lagoon, then the lagoon itself and used by Colenso as the name of the district, sometimes including the whole of the Heretaunga Plains	
+Akitio		About 15 miles south by coast from Cape Turnagain	1-4 Dec 43; 15-16 Apr, 28-29 Nov 45; 19 Feb, 28 Aug 46; 18-19 May, 11 Oct 47; 6-8 Jun, 31 Oct 48; 2-4 May 49; 9 Mar 50; 3-4 Apr 51; 21-22 Apr 52
+Anaura		On Anaura Bay, East coast	4-6 Dec 41; 27 Oct 43
+Aotahi	(Wairua River, Whangarei) Te Aotahi was close to the Wesleyan Mission Station at Tangiteroria on the Wairoa River		23-24 Feb 36
+Aotea	(Barrier Island) Great Barrier in the Hauraki Gulf		13 Oct 43
+Te Apiti	nearly opposite Bare Island; on coast S. of Bare Island; c. 8 miles S. of Bare Island	Te Apiti Stream reaches the coast due east of Elsthorpe and about two miles north of Kairakau	11-12 Feb 46
+Te Apiti	Banks of (Pahawa) River	This name occurs in the list of June 1850, item 2430 No such name is now marked on the Pahaoa River, but a homestead occurs on the Kaiwhata River, some four miles in a direct line from the Pahaoa headwaters	
+Apungaotekura		Near Hallett’s Bay on the east side of Lake Taupo. This place is mentioned in In Memoriam (p. 37) but does not appear in the Journal	16 Feb 47
+Arai (1)		A sleeping place, a half hour’s walk from the following	29-30 Mar, 1-2 Apr 39
+Arai (2)	a rocky headland	Presumably Te Arai, the 53 foot high feature south of The Bluff, Ninety Mile Beach	30 Mar 39
+Arawata lake		From Colenso’s description and route, this would be one of the Lake Half – Swan Lake group near Ninety Mile Beach	2 Apr 39
+Araẁata		The Arawhata Stream forms a conspicuous shingle fan on the coast about three miles south of Flat Point, Wairarapa coast	14 Apr 52
+Te ari aẁai		Alternative name for Tuparoa	20-21 Jan 38
+Te Ariuru	A large village in Tokomaru Bay		
+Tokomaru Bay	(Bagnall and Petersen p.109)	Porter’s map (p. 621) marks Te Ariuru too far north	2-4 Dec 41; 27 Oct 43
+Aropaki		Arrowsmith’s 1850 map shows Aropaki on the west bank of the Whakatane River, opposite Warau hill. This corresponds to a position opposite the Mangatawhero stream mouth	13-15 Jan 44
+Aropauanui	Hawkes Bay	Near the mouth of the Aropaoanui River, north of Tangoio. Arapawanui is an old spelling	13 Dec 43; 7-8 Jul, 9 Dec 46; 16-18 Jun, 30-31 Aug 47; 11-12 Feb 48; 13 Nov 51; 30 Jan 52
+Te Atuaomaharu	topmost crag of Ruahine; Teatuaomahura The highest peak (5028 feet) of the northern Ruahine Mountains		26 Feb 47; 28 Oct 51
+Auckland			Jan (May?), 5-10 Oct 43; 15-22 Dec 44
+Te Aute		About 8 miles north of Waipawa on the Napier/Wellington highway and railway, and about two miles west of Roto a kiwa Lake	27 Feb, 13 Mar, 10-13 Jul 52
+Te Awaiti		At the south of the Oterei River (Bagnall & Petersen, p.219n), Wairarapa coast	27 Feb 46; 19-20 Oct 47; 24-25 Apr, 7 Nov 48; 14-15 Apr 51; 8-10 Apr 52
+Te Awanga		Near the mouth of the Maraetotara Stream between Cape Kidnappers and the Tukituki River, Hawke’s Bay. 9 Dec 43; 29-30 Nov 50. Te Awaateatua. Buchanan (p. 133) notes a ford on the Ngaruroro River called Te Awaoteatua downstream from Fernhill	8-9 Jul 52
+Awanui River	near Te Kawakawa, East Cape (list of 30 July 1844)	Possibly an error for Awatere (q.v.), the river on which Te Kawakawa (modern Te Araroa) was situated - It does not appear to be associated with Port Awanui, a few miles down the coast from the mouth of the Waiapu River	
+Te Awa o te atua		The old name for the lower reaches of the Tarawera River, reaching the sea at Matata, Bay of Plenty	23 Jan 44
+Te Awapuni		On the Waitangi River only a short distance from Colenso’s Mission Station in Hawke’s Bay	9-12 Dec 43
+Awaroa		Awaroa Creek, Whangarei Harbour	4 Oct 41
+Te Awarua	W. side of Ruahine range	Awarua is on the east bank of the Rangitikei River, at the foot of the Mokai Patea ridge from the Ruahine Range. The visit in 1847 is not mentioned in the Journal but is recorded in In Memoriam (p. 49)	(24 Feb 47), 1-3, 6-7 Jan, 12-13 Dec 48; 22-23 Nov 49; 25-27 Oct 51; 23-24 Feb 52
+Awatere River		Flows into Kawakawa Bay, East Cape	Mentioned in the list of 30 July 1844
+Awatoto	Te Awatootoo	On the coast of Hawke’s Bay, south of Napier	Colenso must have passed it on many occasions but it is mentioned in the Journal only on 3-4 July 52
+Aẁea	East Coast	North of Cape Palliser, at the mouth of the Awhea River, a few miles south of Te Awaiti	
+Aẁeanui	E. Coast	Probably to be equated with the Awhea River area	
+Bare Island	E. Coast, a glen opposite	One mile offshore and about 15 miles south of Cape Kidnappers	
+Baridy Bay		Baridy Bay is shown on Arrowsmith’s 1841 map as being the bay immediately south of Flat Point, Wairarapa coast. The name is possibly a corruption of Pararata, the name of a stream entering the Bay. Colenso, in the list of July 1846, puts the name in quotation marks	
+Bay of Islands		1835-1844	
+Bethany		Petane	
+Cape Kidnapper (Cape K.) (C.K.)		Cape Kidnappers is the promontory at the southern end of Hawke Bay	4, 26 May 46; 30 Jul-1Aug 50
+Cape Palliser		The southernmost point of the North Island and the eastern boundary of Palliser Bay	19 Mar, 21 Nov 45; 10-11 Sep 46; 4 May 47; 26-27 Apr, 8-9 Nov 48; 7 Apr 52
+Cape Reinga		One of the promontories of the North Cape complex	31 Mar 39
+Deliverance Cove	Castle Point		15 Nov 43; 14 Mar 45; 1 Nov 48
+East Coast		The coast from Cape Kidnappers to Cape Palliser. As an aid to identification, localities occurring from Castle Point southward have been referred to as being on the Wairarapa Coast	15 Nov-8 Dec 43; 1-19 Mar, 10-21 Apr, 20-29 Oct, 23 Nov-4 Dec 45; 10 Feb-1 Mar,18 Aug-10 Sep 46; 4-28 May, 1-21 Oct 47; 20-26 Apr, 31 May-16 Jun, 25 Oct-8 Nov 48; 24 Apr-15 May 49; 2-18 Mar 50; 22 Mar-17 Apr 51; 7 Apr-6 May 52
+East Cape			Jan 38; Nov 41; Oct 43
+Eparaima	a village in the interior, 10 miles from Porangahau (item 3736, list of June 1850)	Bagnall and Petersen (p. 206) show Eparaima WNW of Wallingford which would place it between the Tutira and Whangai Ranges, and about 20 miles from Porangahau. The present Eparaima trig is about 3 miles north of Wallingford and well to the east of the position shown by Bagnall and Petersen	24-25 Nov 47; 21-22 Nov 50
+Gable End Foreland		The prominent headland north of Poverty Bay	25 Jan 38; 9 Dec 41
+Haruru		At the head of the tidal flats on the Waitangi River, Bay of Islands	26 May 39
+Haukawakawa river	Whangarei district; six miles northwest from Whangarei; Haukawakawa BayNot located precisely	No stream is now so named	18-19 Feb 36; Oct 43
+Haumi		The Haumi River flows into Veronica Channel south of Paihia, Bay of Islands	13 Apr 36
+Te Hautotara		Te Hautotara was east of Dannevirke, at the Mangatera-Manawatu Junction. (Bagnall & Petersen, p.233n)	2-6 Apr, 30 Sep-2 Oct 46; 27-29 Mar, 22-23 Nov 47; 30-31 Mar 48; 9-10 Apr 50
+Te Hawera		Modern Hamua, on the Woodville-Masterton highway, north of Ekatahuna. The name Hawera is still preserved in the district	27-30 Mar 46; 3-6 Apr, 16-18 Nov 47; 5-10 Apr, 21-23 Nov 48; 17-21 Mar 49; 3-5 Apr 50; 14-16 May 51; 23-24 Mar 52
+Hawkes Bay		Used by Colenso to indicate the bay itself and the district bordering the bay	
+Te Heiotepooro	Bleak crags, W. side (of Ruahine) (list of 31 January 1853)	Not located: appears only in the plant lists	
+Te Hekawa		Between Hick’s Bay and East Cape, east of modern Te Araroa	16-17 Jan 43; 25 Nov 41
+Herehere stream (Herehere plains)	The Herehere Stream flows northwards through Havelock North to join the Karamu Creek		16-17 Jan 52 Also mentioned in the lists of September 1847 and 31 January 1853
+Hereheretaunga	The landing place at the further extremity of the Lake (Waikaremoana)	Presumably on Whanganui Inlet. Bagnall & Petersen (p 170) spell Hereheretaua, but I have not found any other references	
+Herekino		The northernmost of the harbours on Northland’s west coast	25 Mar 39
+Herepunga		Arrowsmith’s 1850 map shows Herepunga on the right bank of the Waikaretaheke River, in northern Hawke’s Bay	18 Dec 43
+Heretaunga		The plains on the lower reaches of the Tutaekuri, Ngaruroro and Tukituki Rivers; also called Ahuriri plains by Colenso	
+Heretaunga river		The Hutt River, flowing into the northern end of Wellington Harbour	4 Nov 47; 18 May 48
+Hick’s Bay	East Cape		16 Jan 38; 22-25 December 41; 19-20 & 23-24 Oct 43
+Hikurangi	a high mountain capped with snow near the E. Cape	Mount Hikurangi, Raukumara Range	Not visited by Colenso, but an unnamed Māori was sent to bring back plants which are in the list of 30 July 1844
+Te Hinau		On the E. bank of the Ẁirinaki River, in the Te Ẁaiiti District, in the interior. Not noted by Best (1925) nor marked on Arrowsmith’s 1850 map, but clearly on the lower reaches of the Whirinaki near the junction with the Rangitaiki?	4 Jan 44
+Te Hinau		Occurs on the ticket of Rumex flexuosus 4437, dated 16 Dec 51. The entry in the list of 31 January 1853 reads: Rumex, growing with 4426; … (gravely shores), nr. Ahuriri. This may be Te Hinu, the pa on the Tukituki River of Buchanan (p 136)	
+Hinemaia river		The Hinemaiaia Stream flows into the eastern shores of Lake Taupo at Hatepe	16 Feb 47
+Hinemokai village	On Waiau River, Hawke’s Bay	Arrowsmith’s 1850 map and Bagnall & Petersen (p. 66) show Hinemokai at the junction of the Waikaretaheke and Wairoa Rivers	18 Dec 43
+Hinuera valley		The present Hinuera is on the Rotorua branch railway between Matamata and Tirau	21 Jan 42
+Hinukuku		One of the nearest villages of the Waiomio valley, Bay of Islands but not now traceable	Twenty identified visits between September 1836 and February 1840
+Hobson’s Harbour	Aotea	(Great Barrier Island). Hobson’s Harbour no longer appears, but is probably an earlier unofficial name for Port Fitzroy	13 Oct 43
+Honurora		A large village on the seashore at the mouth of the Uawa River, Tolago Bay	7-9 Dec 41
+Hopekoko	A small stream…	Not identified. No streams of this name are now to be found between Parikanapa and Hangaroa River in Northern Hawke’s Bay	21 Dec 41
+Horahora	near NgunguruThe Horahora River enters the sea at Ngunguru Bay, a short distance south of the mouth of the Ngunguru River		17 Feb 42
+Horoera	A pa halfway between Te Hekawa and Poureatua, East Cape	Horoera marae is on the hillside above Horoera Point, to the west of East Cape	25 Nov 41
+Hororoa	about 3½ miles up the (Kawakawa) river	Not now known	Ten visits noted between February 1835 and May 1840
+Horotutu	Bay of Islands	… the next beach along from Paihia towards the Waitangi River. (Porter 111, n. 83) appears on a specimen of Nephrodium thelypteris in the bound volume of ferns at WELT	
+Houhora Harbour		A tidal inlet at the southern end of Great Exhibition Bay on the east coast of the Northland Peninsula. Mt Camel forms the eastern headland	2 Apr 39
+Huaangarua		This was on the site of Martinborough in Wairarapa (Bagnall & Petersen p.219n). The Huangarua River joins the Ruamahanga just north of the town	4 Apr, 4-5 Nov 45; 18-19 Mar, 17-18 Sep 46; 13-14 Mar, 8-10 Nov 47; 14, 16-19 May, 15-16 Nov 48; 27-29 Mar, 19-23 Apr 49; 20-26 Mar 50; 23-29 Apr 51; 30-31 Mar 52
+Huariki village	nr. Cape Palliser	Bagnall and Petersen (p. 219n) give the position as one mile north of Te Awaiti on the Wairarapa Coast	18-19 Mar, 22 Nov 45; 27 Feb, 9 Sep 46; 6 May 47
+Te Huiakama	A pa about a musket shot from Kaupapa (Turanga or Poverty Bay)	Curiously, Williams (Porter 1974) does not mention a pa of this name	15 Dec 41
+Huiarau Range		The range of hills to the west and northwest of Lake Waikaremoana	30 Dec 41-1 Jan 42; (28 Dec 43)
+Te Humenga	Palliser Bay	Te Humenga Point, the headland on the east side of Palliser Bay	
+Hurunuiorangi	Wairarapa valley	Bagnall and Petersen (p. 218) show Hurunuiorangi on the west bank of the Ruamahanga River almost opposite the confluence with the Tauweru River, near Carterton. A pa still occupies this position	19-20 Mar, 18-19 Sep 46; 10 Nov 47; 18 Apr, 29-30 May 48; 26-27 Mar 50; 29-30 Apr 51
+Hutt Valley (valley of the Hutt)	The Hutt River flows into the northern end of Wel1ington Harbour	In addition to his numerous visits to Petone (Pitoone) at the southern end, Colenso twice travelled the length of the valley to reach the Wairarapa	4 Nov 47; 17 Apr 49
+Te Ihooteata		Arrowsmith’s 1850 map shows this on the east bank of the Waimana River, Bay of Plenty	17 Jan 44
+Ihuraua		Ihuraua Stream flows past Alfredton, 16 miles by road east of Ekatahuna	Although mentioned on 24 March 1846, Colenso never visited the village
+Ikaarangitauira	Sides of R. Tutaekuri	Te Ikaarangitauira is placed by Colenso (Trans. N.Z. Inst. 11: p.85-6 1879) on the banks of the Waitio River which now joins the Ngaruroro (not the Tutaekuri) at Ohiti by Runanga Lake	
+Iringataha		Arrowsmith’s 1850 map and Bagnall & Petersen (p. 66) show Iringataha on the north bank of the Waikaretaheke River	18 Dec 43
+Te Kahakaha		Colenso gives the position as 3 miles NNE of Toreatai. Arrowsmith’s 1850 map shows it west of the northern end of the Maungapohatu ridge and upstream of the Waikare crossing. This suggests that it was not far from modern Pinaki	12 Jan 44
+Kahumingi		Kahumingi is marked on the Masterton – Castlepoint Road several miles east of Tauweru, Kaumingi Stream, with its tributary of Biscuit Creek, flows into the Tauweru River	30-31 Oct, 24 Nov 45
+Kahuraanake	The hill, H. Bay; Kauranaki, near Bare Island	Kahuranaki (2119 feet alt.) is between the Maraetotara and the east bank of the Tukituki. Also spelt Kauranaki	29-30 Dec 51
+Kahuwera stream		Not located. The main streams between Whareora and the Ngunguru River are the Taheke and Waitangi	4-5 Oct 41
+Kaihoata stream		Kaiwhata Stream north of Flat Point, Wairarapa coast (Bagnall & Petersen, p.213). 15 Mar 45; 4-7 Sep 46; 27 Apr 49 (as Taihoata); 10 Apr 51. Kaikohi. Modern Kaikohe, west of Bay of Islands	8-9 Jan 36
+Te Kaikokirikiri village	head of Wairarapa valley	Bagnall & Petersen (p. 218) place this on the present site of Masterton	5-9 Apr, 31 Oct-4 Nov 45; 20-24 Mar, 19-23 Sep 46; 8-12 Apr, 13-15 Nov 47; 12-18 Apr, 17-20 Nov 48; 22-27 Mar 49; 27-31 Mar, 1 Apr 50; 30 Apr, 1-12 May 51; 25-30 Mar 52
+Kaikoura Stream	near the Rotoatara Lake	Buchanan (p. 139) so names a stream two miles north of Otane. He also notes Kaikora as the original name for Otane	15-16 Dec 48
+Kaiku	Cape Kidnapper		Not located but occurs in the list of July 1848
+Kaimatangi	30 miles SW. from Ahuriri, inland	A trig point in the Ahimanawa Range near Tarawera might be intended if the direction is an error for NW.	The name occurs in the list for July 1846
+Kainganui		A hill described as on the north bank of the Waikaretaheke River, two miles from Iringataha and two miles from Herepunga. This appears to be the trig east of the McLean’s Road – Titirangi Road junction	18 Dec 43
+Kaipara (harbour)		On the west coast north of Auckland	5 Feb 42; 7-10 Feb 44
+Kaipatiki	A small village about two miles distant from Paihia	Kaipatiki Creek drains into the south arm of Waitangi Inlet	22 Oct, 10 Dec 37; 1 Nov, 6 Dec 40; 15 Feb 41; 9, 25 Apr 55
+Kairakau On the coast	26 miles south of Cape Kidnappers, formerly Manawarakau (q.v.) Colenso uses both names		
+Kaitaia		(Mission Station) Modern Kaitaia	26-28 Mar, 4-8 Apr 39
+Kaitara	(forest)Known to the early settlers as Morrison’s Bush (Bagnall & Petersen p.267n)	The present locality of Morrison’s Bush is three miles south of Greytown The forest bordered the Ruamahanga River between here and Martinborough (Huaangarua)	
+Kaiwa	Wangarei	Not located	mentioned in the list of 19 November 1844
+Kaiwaka river		A tributary of the Waiohingaanga (Esk) River, Hawke’s Bay	22-23, 30 Apr, 1 May 46; 23-24 Jan 49; 3-4, 10-11 Oct 50
+Kaiẁaraẁara		At the southern end of the western shore of Wellington Harbour. Reclamation has radically altered the shoreline in this area. This was the starting point of the track over the hills to the villages on Cook Strait, but Colenso would have passed it going to and from Wellington	5? May 48; 7 Apr 49
+Kaokaoroa (Te Kaokaoroa)	plains, Kaokaoroa	The Kaokaoroa Range is west of the Tukituki River, opposite Opapa	The name occurs in a list of 31 January 1853
+Te Kapa		Buchanan cites two localities of this name, one near Lake Roto-o-kiwa, the other near the Tukituki River on the other side of the Kaokaoroa Range. Colenso on one occasion associates the name with Kaokaoroa, so presumbably the second of Buchanan’s places is intended	8-9 Mar 49
+Te Kape	¼ of a mile from Mangatepa (Ruatahuna)	Best shows it on the east bank of the Whakatane River at the junction with the Mangaorongo Stream. Arrowsmith’s 1850 map shows it further downstream	
+Te Kapemaehe (Te Kapemaihi)		Probably renamed Petani (Bethany) at about Christmas 1848. The Journal first mentions Petani in January 1849	17-18 Jan, 16-18 Jun 45; 21-22 Apr, 3-4, 8-10 Jun, 21-25 Nov 46; 12-15 Jun, 27-28 Aug, 1 Sep 47; 22-23 Feb, 9-10, 14-15 Aug, 13-14 Oct, 16-17 Oct 48
+Te Karaka		Possibly Waikaraka (q.v.)	17 Feb 42
+Kareka Lake		Lake Okareka, Rotorua	7 Jan 42
+Kariawa		A pa in the vicinity of Porangahau	7-10 Mar 45
+Te Kauika (Kawaka)	Up river from Pihoi, Whangarei, but not located		30 Sep, 1 Oct 41
+Kaukopakopa		Kaukapakapa, at the southern end of Kaipara Harbour	8-12 Feb 42; 8-9 Feb 44
+Kaupekahinga	A native village on the banks of the Ruamahanga river	Not located but presumably between Greytown and Martinborough	19 Apr 49
+Kaurinui		Kaurinui Creek flows into the Bay of Islands near the south head land of Waikare Inlet	24 Jan, 25 Sep, 20 Nov 36
+Te Kawakawa	Bay of Islands	Modern Kawakawa, on the river of the same name, which rises near Kaikohe and flows into the southern end of the Bay of Islands Colenso made visits at two-weekly intervals for nearly the whole of his residence in the Bay	
+Te Kawakawa	East Cape	Modern Te Araroa	[16? Jan 38]; 23-25 Nov 41; 19-21, 23-25 Oct 43
+Kawatau River	interior	Kawhatau River, a tributary of the Rangitaiki entering north of Mangaweka	The river is mentioned in the list of June 1850 and would have been crossed in November 1849
+Kaweka Mt	½ way between H. Bay and Taupo (brought me by one of our surveyors)	The Kaweka Range, at the head of the Tutaekuri River	
+Kereru (Kerera) lake		Lake Tauanui, about eight miles SSE of Kaikohe. So identified by Bagnall & Petersen and Colenso’s route leaves no doubt of the correctness of this conclusion	5 Jun 36
+Kerikeri		The locality on Kerikeri Inlet, Bay of Islands	15 Jan, 2 May 35; 20-22 Apr,?-4 Nov 37; 22-24 Aug 38; 11-12 Apr 39
+Kerikeri waterfall	Bay of Islands		
+Kerikeri Falls	on the River to the north of the town of Kerikeri		
+Te Koau		A watering place on the coast south of Castle Point. This is possibly the Ngakauau Stream	14 Mar 45
+Kohinurakau		Bagnall & Petersen (p. 206) show this village on the west bank of the Tukituki River, southwest from Pakipaki	12-20 Sep, 18-20 Oct 45; 27-28 Jan, 23-24 Jun, 6-7 Oct 46; 6-8 Jan, 9-10 Sep, 29-30 Nov 47; 21-22 Sep 48; 1-4 Jun, 22-25 Oct 49; 9-11 Jul, 15-16 Nov 50; 27-28 May, 8-9 Aug, 30-31 Dec 51; 19-20 Jan, 21-22 Jul,18-20 Aug 52
+Kohumaru		On a stream of the same name, a tributary of the Oruaiti River which flows into Mangonui Harbour	9 Apr 39
+Te Kohurau		Colenso’s description suggests Kuripapango, 4100 feet alt., between the Ngaruroro and the headwaters of the Tutaekuri Rivers. This is also borne out by Buchanan (p. 142)	16 Feb 52
+Kopau River	the upper part of the Kawakawa	Possibly the Pokapu Stream, a southern tributary of the Kawakawa catchment	1-2 Jun 36
+Te Kopi		On the east side of Palliser Bay, just north of the mouth of the Putangirua Stream	20-24 Mar, 2-3 Apr, 6-10 Nov, 18-21 Nov 45; 2-4 Mar, 13-17 Mar, 11-16 Sep 46; 15-19 Mar, 30 Apr-4 May, 22-26 Oct 47; 27 Apr-1 May, 19-24 May, 9-13 Nov 48; 30 Mar-2 Apr 49; 17-19 Apr 51; 6 Apr 52
+Korohe		At the southeast corner of Lake Taupo. It is possibly the same as Waimarino of the 1847 visit	1-3 Dec 49
+Kororareka		Modern Russell, Bay of Islands Visits at approximately monthly intervals were made for most of Colenso’s residence in the Bay	
+Kotere (Kotore)	Distant about 4 Miles from Kawakawa but not located		15 Sep, 13 Oct 39
+Te Kotipu Wood		Reached an hour after leaving the head of the Mohaka River (Taharua River) This suggests that the wood was at the base of Te Iringa (4073 feet alt.) in State Forest 90	
+Te Kotukutuku		Not located. Colenso describes it as being at the head of the Wairarapa valley and on the edge of the river, and entrance to the long forest. Assuming the river to be the Ruamahanga, the vicinity would appear to be Mt Bruce, north of Masterton	12-13 May 51
+Kowhaia River	dense forest near Manawatu	Not located	The name appears in the list of June 1850
+Te Kupenga		Bagnall & Petersen (p. 175 & 66) place Te Kupenga on the Rangitaiki River upstream from Te Rekemanuka, but Arrowsmith’s 1850 map shows it slightly downstream	23 Jan 44
+Kuraẁaẁanui	Mr Barton’s sheep station	The Whawhanui River reaches the sea at White Rock, Wairarapa coast	19 Mar 45; 2 Mar 46; 5 May 47; 21 Oct 47
+Kuripapango		On the Ngaruroro River, where the Napier – Taihape Road crosses	16 Oct 51
+Makakahi River		An eastern branch of the Mangatainoka River, the junction a short distance south of Pahiatua	15-16 Nov 47; 21-22 Mar 48; 25 Mar 52
+Makaroro River		One of the headwaters of the Tukituki, rising in the Ruahine Mountains and joining the Waipawa River	26-27 Feb 47; 11-13 Jan, 14 Dec 48; 28-29 Oct 51; 26-27 Feb 52
+Maketu		At Town Point, Bay of Plenty	24 Jan 44
+Manawarakau		Kairakau, on the coast 26 miles south of Cape Kidnappers. Colenso uses both names	7 Dec 43; 4-5 Mar, 2-3 Nov 45; 20-21 Aug 46; 14-15 Jan, 26-27 May, 2-4 Oct 47; 14-15 Jun, 26-27 Oct 48; 8-10 May 49; 4-5 Mar, 27-28 Nov 50; 25-26 Mar 51; 1-4 May 52
+Manawatu		For the present purposes, this district is treated as being between the Te Whiti clearing in the north and the tributaries of the Manawatu River in the southern Hawke’s Bay	24 Mar-6 Apr, 23 Sep-2 Oct 46; 27 Mar-6 Apr, 15-23 Nov 47; 29 Mar-11 Apr, 21-27 Nov 48; 13-21 Mar 49; 3-11 Apr 50; 12-23 May 51; 17-25 Mar 52
+Manawatu River (District)	The main river draining the eastern side of the southern Ruahine Ranges	Colenso knew this river only on its eastern reaches, as he never entered the Gorge	
+Mangahane River (Mangohane River)	The Mangaohane River rises on Otupae, the northern outlier of the Ruahine Ranges, and enters the Rangitikei River		17 Oct 51; 18 Feb 52
+Manga-a-noka River		Possibly the Mangaone River which flows north from headwaters east of Ekatahuna	27 Mar 46
+Mangamako	a little wood near the Rangitaiki River	Not otherwise identifiable	6 Jan 42
+Mangamauka	a small rivulet	Mangamauku Stream is a tributary of the Waikaretaheke River, entering it on the north side near Rosskeen	19 Dec 43
+Mangaonuku River		On the edge of Ruataniwha (Takapau) plains. The river flows south to join the Waipawa River to the west of the town of Waipawa	5-7 Feb 45; 29 Dec 47
+Mangare	Wangarei	A Mangere Stream joins the Wairua River near Kokopu west of Whangarei: Colenso’s village was probably on this stream	25 Feb 36
+Mangarewa River		Rises on the Mamaku Range and flows northeast to join the Kaituna in the Bay of Plenty	13 Jan 42
+Mangaotai River		Not located	
+Te Mangaroa River		The Mangaroa River which flows north through Whitemans Valley to join the Hutt River at Te Marua north of Upper Hutt	4-5 Nov 47
+Mangatainoka River		Rises in the Tararua Ranges near Ekatahuna and flows north past Pahiatua to join the Manawatu near the Gorge	30 Mar 46; 16-17 May 51
+Mangataẁainui River		This is a northern tributary of the Manawatu between Norsewood and Matamau	6 Apr 46; 10-11 Apr 50
+Mangataẁiri		The Mangatawhiri Stream joins the Waikato River above Mercer	31 Jan-1 Feb 44
+Mangatété		Probably Mangatoetoe, near Kaiaka	8 Apr 39
+Mangati Beach		Not located but presumably one of the beaches near the Mimiwhangata Peninsula	20-21 Dec 39
+Mangatuna		On the Uawa River, inland from Marau Point, between Anaura and Tolago Bays	6-7 Dec 41
+Mangaiwai		Mangawhai Harbour or Estuary is about three miles south of Bream Tail	14 Feb 42
+Mangaiwata	The Mangawhata Stream follows the line of the Taupo-Napier Road (Highway 5) from Titiokura Summit to the Mohaka River	The pass was a dangerous crossing of the stream (A fearful pass)	23, 30 Apr 46; 11 Feb 47
+Mangaẁero	a small village about four miles from Mr Stack’s Rangitukia	Bagnall & Petersen show it on the Waiapu river upstream of Rangitukia and Pukemaire, but Arrowsmith’s 1850 map shows it WNW of Rangituklia!	23 Oct 43
+Mangungu		The Wesleyan mission station on the Hokianga River, about 25 miles from the heads; on the south bank of the Waihou River near the confluence with the Mangamuka River	21-22 Mar 39
+Manukau Bay		Modern Manukau Harbour	1-4 Feb 42; 10 May 43; 1, 5 Feb 44
+Maraetai	(Fairburn’s Mission Station)	On the south shore of Tamaki Strait, east of Howick	3-12 Feb 38
+Maraetai	(Maunsell’s Mission Station)	On the south bank close to the mouth of the Waikato River	29 Jan-1 Feb 42
+Maraetaha River	H. Bay	The name occurs only once, and that amongst specimens from the vicinity of Kahuranaki (list of June 1850) It is probably an error for Maraetotara, which river flows past the foot of Kahuranaki	
+Maraetotara River	at base of Kahuranake Hill	Enters the sea east of the Tukituki River	The name occurs in the list of 31 January 1853
+Maramanui River		This name is not now recognized. Colenso appears to apply the name to the Wairua River above the falls	25 Feb 36
+Maramatitaha	a high precipitous & very dangerous cliff	Apparently the cliffs at the eastern end of Whangaimoana Beach, Palliser Bay	3 Apr 45
+Marumaru		Marumaru is shown on Arrowsmith’s 1850 map as being on the Whakatane River downstream from the junction with the Waikare Stream. Bagnall & Petersen (p. 66) show it in the angle between the two streams	15 Jan 44
+Maruteangi	on the E. bank of the Wakatane river … about 12 or 14 miles from Pipi	Arrowsmith’s 1850 map shows Maruteangi at the beginning of Colenso’s route to the villages of Maungapohatu. Bagnall & Petersen (p. 66) mark Omaruteangi at the junction of the Whakatane and a stream from Maungapohatu, presumably the Manangaatiutiu	9-10 Jan 44
+Mata	Mr Monro’s residence on the N. bank of the (Hokianga) River	Te Mata Point near Pupuwai Creek, Hokianga Harbour. Drury (1853, p.870) mentions an Englishman’s house (Munro) at the point	22-23 Mar 39
+Te Mata		A sulphur spring between the Whakatane and Rangitaiki Rivers	22 Jan 44
+Te Matau-a-maui		Cape Kidnappers. Colenso also applies the name to the ridge leading to the Cape	8 Dec 43
+Te Matai		Arrowsmith’s 1850 map shows Te Matai on the south bank of the Waikaretaheki River, upstream from the confluence with the Waiau. Bagnall & Petersen (p. 66) show it on the north bank opposite the confluence. Colenso’s description favours the Arrowsmith position. Matai is a modern location on the south bank downstream from the confluence. 19 Dec 43 (Bagnall & Petersen p.169 give Colenso’s arrival as the 18th)	
+Mataikona		The Mataikona River enters the sea a short distance north of Castle Point	Nov 16-1 Dec 43; 12-13 Mar, 11-15 Apr, 25-29 Oct, 26-28 Nov 45; 19-23 Feb, 29 Aug-3 Sep 46; 13-18 May, 11-13 Oct 47; 2-6 Jun, 31 Oct-1 Nov 48; 28 Apr-1 May 49; 9-12 Mar 50; 4-7 Apr 51; 17-21 Apr 52
+Matamata		Thames Valley. The village of Colenso’s day was further north than modern Matamata, in the vicinity of Waharoa	20-21 Jan 42
+Matapouri		Matapouri is about one mile south of Sandy Bay	19 Dec 39; 23-24 Sep 41; 6-7 Oct 41; Oct 42 (December 1837 and March 1841 are mentioned in Icones Plantarum 6 t 567 1843)
+Matarauẁi	near Cape Kidnapper; Mataraua	Presumably the same place as Matarauwe on Bagnall & Petersen’s map (p. 206) and located about 8 miles south of Cape Kidnappers	4 Dec 45; 10 Feb 46; 17-18 Oct 49; 21 Mar 51
+Mataruahou		The headland of the Bluff Hill, Napier, now overlooking the Port of Napier	12 Dec 43
+Te Matata		Bay of Plenty. Colenso’s description indicates that the Rangitaiki River at this time reached the sea to the west of its present mouth. This is confirmed on Arrowsmith’s 1850 map on which the Rangitaiki and Tarawera Rivers have a common mouth. Matata is described as on the south bank and a position east of the modern town is indicated	23 Jan 44
+Matatoto	our old sleeping place	On the Makaroro River, and probably close to the confluence with the Waipawa	29-30 Oct 51
+Matatu	a small stream	Two and a quarter hours’ march from Huaangarua on the way to Te Ahiaruhe. Not further identified, although Porter (p. 421n quoting Bagnall) refers to the Matatu track up the Wairarapa Valley	19 Mar 46
+Matauri		On Matauri Bay, opposite the Cavalli Islands, Northland	10-11 Apr 39
+Matauẁi		Matauwhi Bay is immediately to the south of Kororareka Bay; the town of Russell extends southwards to the beach. Bagnall & Petersen’s map (p38) spells it Matahi	4 Jun 37
+Matuku		The actual site of Matuku, later known as Kohimarama, is on the western point of the long razor-backed ridge, on the eastern knob of which is the Matuku trig. It is situated on Mr. J. Duncan’s ‘Hiwera’ station. (Bagnall & Petersen, p.257n). The pa site is now marked on the latest edition of the map	23-24 Feb 47; 3-6 Jan, 6-12 Dec 48; 23-27 Nov 49; 18-25 Oct 51; 19-23 Feb 52
+Maukopakopa		Kaukopakopa, southern Kaipara Harbour	8-9 Feb 44
+Maunga Nui (Maunganui)		Mt Maunganui, at the entrance to Tauranga Harbour	6, 12 Jan 38
+Maunga nui	a sandy island	Te Wakatehaua Island, The Bluff, Ninety Mile Beach	30 Mar 39
+Maunga Poẁatu		Maungapohatu, a prominent ridge on the western side of the Huiarau Range, overlooking the Ruatahuna valley	11 Jan 44
+Maungarei		Not located and not mentioned by Buchanan. It is noted by Colenso in the entry for October 16, 1851, as having been crossed the previous day on the march over steep fern-covered hills between leaving the Ngaruroro River and reaching the Kuripapango ford. The Clematis mentioned in the Journal entry is possibly 4251 Clematis … of the list of 31 January 53	15 Oct 51
+Maunga Tapu		Now an eastern suburb of Tauranga	7 Jun 38; 15-18 Jan 42; (Bagnall & Petersen p.125)
+Maungatautiri	An elevated district situated nearly midway between the east and west coasts	The mountain lying to the west of Arapuni on the Waikato River	
+Maunga Turoto		A village within easy riding distance of the Waimate Mission Station. Not located but not to be confused with modern Maungaturoto which is much further south	5 Feb 37
+Maunu	a deserted village near Te Waiiti, Wangarei	A place called Maunu is marked on Highway 14 west of Whangarei	22 Feb 36
+Mawe	Morning, rode to Mawe from Waimate	Heke’s pa Puketutu near Lake Omapere was sometimes referred to as Te Mawhe. (Porter p.344n quoting Cowan)	12 Aug 38
+Mimiha		Bagnall & Petersen (p. 246) place the village of Te Mimiha on the bank of the Mohaka River,  (close to the present bridge on the Taupo-Napier highway)	11-12 Feb 47
+Mimiẁangota		Mimiwhangata is on a prominent peninsula forming the southern headland of Whangaruru Bay	8 Oct 41
+Moäwango River (Moeawango)	The Moawhango River rises on the western side of the Kaimanawa Mountains and flows south to join the Rangitikei southeast of Taihape		22 Feb 47; 6 Dec 48
+Moeangiangi River	(Hawke’s Bay) 10 miles inland from the sea	Moeangiangi Stream reaches the coast 25 miles north by road from Napier	13-14 Dec 43; 25-26 Jul 45; 11-12 Nov 51; 28-30 Jan 52
+Mohaka (Mohaka River)	A major river of northern Hawke’s Bay		14-15 Dec 43; 29-30 Jul 45; 23-25 & 29-30 Apr 46; 11-12 & 15 Feb 47; 16-17 Feb 48; 4-5 & 9 Oct 50
+Mokaipatea (Mokai Patea)	The prominent ridge on the western side of the Ruahine Range descending from Rongotea to the Rangitikei River		Mentioned in the list of Jun 1850
+Mokau Beach	Between Paparaumu & Owae	Mokau Bay is in Whangaruru Bay between Oakura and Helena Bays	7 Jan 41
+Mokau		On the Mokau Inlet, northern shore of Waikaremoana	27-28 Dec 43
+Mokoia Island	Lake Rotorua	A visit was made to the island to examine a tree, reported by local Māori, which Colenso concluded to be Vitex littoralis (V. lucens), unusual in this locality	12 Jan 42
+Mokorau		Mokarau Stream is on the shore of Ahipara Bay at the southern end of Ninety Mile Beach	25 Mar 39
+Motukaroro		Close to Mawhai Point, the southern headland of Tokomaru Bay	4 Dec 41
+Motukino		Motukino is just south of Opepe on the Taupo-Napier highway	4 Dec 49
+Te Motu o Taraia	a potatoe plantation	Bagnall & Petersen (p 206) show this at the present site of Wanstead, inland from Pakowhai on the coast of southern Hawke’s Bay province	
+Motuowai (Motu-o-wae)	…a small wood on the bank of the Waipaoa (Waipawa River), and on the SW. edge of Te Ruataniẁa plain	Not located	11-12 Feb 45; 29 Dec 47; 19-20? Nov 49; 27 Feb 52
+Moturoa		Moturoa was close to the site of the old military post beyond the Waipunga crossing (Bagnall & Petersen p.257n), (on the Taupo-Napier Road)	15 Feb 47
+Motutere		On the eastern shore of Lake Taupo between Jellicoe Point and Motutere Point	17 Feb 47; 3-4 Dec 49
+Mount Camel	Northern extremity of N. Island Above Perpendicular Point on the northern entrance to Houhora Harbour, Northland	Now known as Houhora No. 2, but known to Colenso by the alternative name of Maunga Taniwa	
+Mowae		A village, now lost, in the vicinity of the Waimate Mission Station	
+Mukamukanui		Bagnall & Petersen (p. 218) locate Mukamukanui at the mouth of Mukamuka Stream on the western side of Palliser Bay	6-7 Mar 46; 19 & 28-29 Apr 47; 19 May 48; 3-4 Apr 49
+Murimotu		Not located but situated some 20 miles west from Matuku (Bagnall & Petersen p.287)	27 Nov 49
+Napier	Napier was not formally laid out until 1856 so collections labelled as from Napier post-date that year		
+Te Ngaaue Village	Ahuriri	Te Ngaue, the village of the Chief, Te Hapuku, was on the Ngaruroro River beyond Pakowhai (Bagnall & Petersen, p.237)	
+Ngaawapurua		Ngawapurua is located on the north bank of the Manawatu River immediately to the east of the junction with the Mangatainoka	Mar-1 Apr, 26-28 Sep 46; 1-3 Apr, 18-19 Nov 47; 4-5 Apr, 23 Nov 48; 16-17 Mar 49; 5-6 Apr 50; 17-21 May 51; 22-23 Mar 52
+Te Ngae Mission Station		On the eastern side of Lake Rotorua	7-13 Jan 42
+Ngaere		Te Ngaere, opposite the Cavalli Islands, Northland	10 Apr 39
+Te Ngaere	Heretaunga	Not located	Mentioned in the list of 31 January 1853
+Ngamahanga		Arrowsmith’s 1850 map and Bagnall & Petersen (p. 66) show Ngamahanga on the west bank of the Whakatane River, not very far below the confluence with the Waikare Stream. Best’s map shows it on the east bank	16 Jan 44
+Ngamoerangi		… the important coastal pa … long since swept away by the sea (Guthrie Smith, Tutira, 1921, p.64). Colenso indicates Ngamoerangi as being an hour’s walk from Te Kapemaihi and a short distance from Tangoio. This would suggest that the village was in the vicinity of Whirinaki Bluff, possibly on the Pakuratahi Stream	18-20 Jan 45
+Ngapihao	A romantic and craggy point of land … about 2 miles from Ẁaraurangi		
+Ngapihau		Not definitely located	12 Apr 51
+Ngaromaki The Bluff	on Ninety Mile Beach		30 Mar, 1 Apr 39
+Ngaroto		Ngaroro, summit of Ruahine. A name given by Colenso and his party to a favourite camping site on a western spur of the Ruahine Range below Te Atuaomahuru (Bagnall & Petersen, p.271n)	8-10 Jan, 13-14 Dec 48; 21-22 Nov 49
+Ngaruai	2½ miles from Waikino (Bay of Islands)	Not further located	16, 23 Aug, 20 Sep 40
+Ngaruawahie		Ngaruawahia, at the junction of the Waikato and Waipa Rivers	27 Jan 42 (without landing); 30 Jan 44
+Ngaruroro River		Rises in the Kaimanawa Mountains and in flowing south, skirts to the west of the Kaweka Range, crosses the Takapau Plains to pass between Napier and Hastings, discharging into Hawke Bay at Clive	16 Sep 47; 13 & 16 Oct 51; 16 Feb 52
+Ngatahorahora stream	Forest beyond Te Hawera	Not located	The name occurs in the list of September 1847
+Te Ngau a te Hanehane (Te Ngautehangehange)	Not located unless it be the Waiotenoanga Stream, a tributary of the Waiomio		26-27 Feb 36; 13-14 Feb 44
+Ngauwaka		Colenso places this about a mile NNE from Toreatai, (west of Maungapohatu)	12 Jan 44
+Ngawakatatara	Ngaẁakatatara	Ngawakatatara was five miles downstream from Patangata, on a terrace on the west bank of the Tukituki (Bagnall & Petersen, p.219n)	24 Apr, 20 Oct 45; 28 Jan, 8-9 Apr, 30 Jun-1 Jul 46; 24 Mar, 22 & 27 Sep, 16 Dec 48; 9 Mar, 15-16 May, 15-16 Nov 49; 4, 6 Feb, 15-16 Apr, 11-12 & 16-17 Jul, 16 Nov 50; 27 May, 11-12 Aug, 31 Oct 51; 17 Jan, 20-21 Jul, 23 Aug, 20-22 Sep 52
+Ngunguru		On the coast north of Whangarei Harbour	18-19 Dec 39; 20 Jul, 22 Sep, 5 Oct 41; 17-18 Feb 42
+Nihonui	Bay of Islands	Not located	
+Nukupure		A village on the coast between Hokianga and Whangape	23 Mar 39
+Ohariu		At the mouth of the Ohariu Valley, commonly known as Makara, on the Cook Strait coast west of Wellington City	5-8 May 48; 4-7 Apr 49
+Ohaua		On Ohau Bay, at the northern end of the Terawhiti block in the southwest corner of the Wellington peninsula	8 May 48
+Ohawini		Whangaruru South. Ohawini Bay is at the western head of Whangaruru Harbour	11 Oct 41
+Ohinemutu		On the western shore of Lake Rotorua	10 Jan 42
+Ohineriu		On the tussock flats between the head of the Rangitaiki and Taharua Rivers, but not now marked	15-16 Feb 47
+Okahu		Presumably along the Ruamahanga River between Martinborough (Huaangarua) and Te Ahiaruhe (near Carterton) but not located	10 Nov 47
+Okokoro	near the present Pakipaki (Colenso, In Memoriam p.6)		4 Feb 45; 27 Feb 52
+Okorewa	The small fishing village at the mouth of the lake	(Lake Onoke on Palliser Bay) (Bagnall & Petersen p.215)	24 Mar, 1-2 Apr 45
+Okura		Between Pauanui and Manawarakau, mentioned only as a place where there was respite from the rocks and stones of the coast route	7 Dec 43
+Omarunui			
+Omoekau		About two miles inland from the mouth of the Hurupi Stream, on the Whangaimoana. (Bagnall & Petersen p.232n). Moikau is a locality on the Turanganui River, Wairarapa, a mile beyond the end of the Whakatomotomo Road, about a mile from Bagnall & Petersen’s position	3 Apr 45; 17 Mar 46
+Onaua	Cook’s Straits	On Ohau Bay, at the northern end of the Terawhiti Block in the southwest corner of the Wellington Peninsula	
+Onehunga		Modern Onehunga, on the northeastern shore of Manukau Harbour	5 Feb 44
+Te Onepoto	Waikare	The village on Lake Waikaremoana at the outfall of the lake	24-29 Dec 41; 20-26 Dec 43
+Onepoto	Mr Alexander’s trading station	On the southern side of modern Bluff Hill, Napier, and originally on the shore of Ahuriri Lagoon	
+Te Onepu		Arrowsmith’s 1850 map marks Onepu on the west bank of the Whirinaki about halfway between the Okahu Stream and the Rangitaiki	4 Jan 44
+Te Onetapu		The rain-shadow area to the east of the Tongariro group of volcanoes	18 Feb 47
+Onewaka	on the boldly-curved bank of the river Kopau (the upper part of the Kawakawa)	Not located	1-2 Jun 36
+Opaoho	a village about 4½ miles from the Kawakawa … on the brow of a very high hill	Not located	13 Oct 39; 9 Feb, 8 Mar, 10 Oct 40; 17 Jan 41
+Oparapara	Ruahine Mountains; Parapara	Te Atuaoparapara (5450 feet alt.) is at the head of the Waipawa River on the main divide	The name appears in one form or another in the lists of July 1846 and 31 January 1853
+Oparua		On the Makororo River. Not located and not mentioned by Buchanan	7-8 Feb 45
+Opitonui	…between Tarawera and the edge of the Taupo plains (In Memoriam p.35)	Kopitonui Stream flows from Kaimatangi on the west of the Taupo-Napier Road two or three miles north of the old mineral baths at Tarawera	15 Feb 47
+Oporae	(a small village lately formed on the banks of the Ngaruroro River)	Not mentioned by Buchanan	
+Oputao		Oputao is a short distance southwest of Ruatahuna, Urewera	3-4 Jan 42; 29-30 Dec 43; 6-8 Jan 44
+Orarotauira	A small village on the Waiohingaanga River	Not located	22 Apr, 1 May 46; 9-10 Feb 47
+Orauta	about six miles distant (from Kawakawa)	The present Orauta Mission School is on the south side of the Otiria Stream at Tuhipa	10 Nov 39; 5 Jan 40
+Oroi		Oroi, on a broad grassy flat sheltered by a still extensive karaka grove, was about two miles south of the present Tora station. (Bagnall & Petersen, p.219n). The Oroi Stream enters the sea about two miles north of Te Kaukau Point on the Wairarapa coast	10 Mar, 21-22 Nov 45; 27-28 Feb, 1-2 Mar, 10 Sep 46; 5-6 May, 20-21 Oct 47; 25-26 Apr, 7-8 Nov 48; 15-17 Apr 51; 7-8 Apr 52
+Orona		Best 1897 (p63n) gives … Orona, or Hamaria – its modern name. The topographic maps give Hamuria as an alternative name for Halletts Bay on the eastern shore of Lake Taupo just south of the Hinemaiaia Stream which was Colenso’s access route to the lake	16-17 Feb 47
+Orongorongo		At the mouth of the Orongorongo River, west of Palliser Bay	24-25 Mar, 10-11 Nov 45; 20 Apr 47
+Oropa	distant about 4 miles (from Kawakawa)	Not located	17 Feb, 10 Nov 39; 5 Jan 40
+Oroua River		A tributary of the Manawatu on the western side of the Ruahine Range	30 Nov-2 Dec 48
+Oruhi		Oruhi was at the mouth of the Whareama River, south of Castle Point	14 Mar 45
+Oruneke	part of Oruru	The Oruru River flows north into Doubtless Bay. Oruneke has not been located	8-9 Apr 39
+Otahuhu		The Mission Station of W. T. Fairburn, Colenso’s father-in-law. The station was close to the shore of the modern suburb of Auckland	7-8 Feb 38; 2-4 Feb 41; Jan 43; 2-5 Feb 44
+Otakahia		Three hours’ march north from Matapouri, which suggests Sandy Bay on the south side of Whananaki Inlet	19-20 Dec 39
+Otamarakau		On the Bay of Plenty coast at the eastern end of Pukehina Beach	23 Jan 44
+Otamarora		On the Bay of Plenty Coast. Arrowsmith’s 1850 map indicates it west of the [old] mouth of the Rangitaiki River, very close to modern Matata. Drury [1854, p.61. 6 Jun 1854] places it 2½ miles west of the junction of the Matata and Orini rivers and a mile from the mouth	23 Jan 44
+Otamatea inlet	Kaipara Harbour	The Otamatea River enters the Harbour almost directly opposite the harbour entrance	12-13 Feb 42
+Otanenuirangi (Tanenuiarangi)	Bagnell and Petersen (p	23) show Otanenuiarangi on the southern bank of the Ngaruroro River immediately north of Te Pakiaka Bush	
+Otara		Otara was situated at a spot a mile or so from the present township of Ohingaiti. A ford existed opposite the village and was in use until badly washed out by floods in the ’nineties. The present Otara road bridge on the Ohingaiti-Rangiwahia road is slightly upstream from the old village and ford (Bagnall & Petersen, p.292n)	
+Otaraia		Wairarapa valley; Oteraia. Otaraia is on the bank of the Ruamahanga River at its closest approach to the Martinborough-Lake Ferry Road	4 Apr, 6 Nov 45; 18 Mar, 16-17 Sep 46;  14-15 Apr 47; 25-26 May, 14-15 Nov 48; 29 Mar 49; 22-23 Apr 51; 31 Mar-1Apr 52
+Otawao	Waikato	The Mission Station on the site of modern Te Awamutu	24-26 Jan 42
+Otawao	Manawatu	Bagnall & Petersen (p. 206) show Otawhao on the west bank of the Manawatu River south of Dannevirke. They state that The village was south of Otawhao-Manawatu junction between Kumeroa and Dannervirke (p. 233n). Otawhao is a locality on the south side of the Manawatu east of Kumeroa	1-2 Apr, 28-29 Sep 46; 19-22 Nov 47
+Oterango	Cook’s Straits	At the southern end of the Terawhiti block in the southwest corner of the Wellington peninsula	8 May 48
+Otihere		Otiere … pa, on Ihooterei Island (Buchanan p.162), (on the old Ahuriri Lagoon)	19 Jun 49
+Otiki		Colenso gives the Māori name for East Cape as Otiki; it is also the name of the trig station at the Cape	17 Jan 38; 25 Nov 41
+Otuihu		Otuihu was situated on the upper harbour on a bluff on the south headland of Waikare Inlet (Bay of Islands) (Bagnall & Petersen, p.64n)	Colenso records numerous visits at roughly monthly intervals from February 1835 to October 1839
+Otukopeka		Arrowsmith’s 1850 map shows a hill so named west of Ahikereru, Urewera. It is marked by a modern trig	1 Jan 44
+Otumoetai		Now a suburb of Tauranga	7-10 Jun 38; Jan 42 (15-18 in Bagnall & Petersen, p.125)
+Oturereawa River		Otureawa River Otuareiawa Stream joins the Moawhango River just north of the latter’s confluence with the Rangitikei. This is just below the site of Matuku pa	28 Oct 51
+Otuẁareana	a small wood	About two miles south of Otaraia, on the Ruamahanga River, Wairarapa	3-4 Apr 45
+Oue		Colenso gives this as 1½ hours, about 5 miles, from Kawakawa, but it has not been further located	18 Nov 38
+Ouepoto	A sandy flat … near Cape Turnagain	Arrowsmith’s 1850 map shows Uepoto just north of Black Head. This corresponds with modern Aramoana, and should not be confused with Te Onepoto south of Waimarama. Colenso’s spelling is consistent and is supported by Arrowsmith’s version	6 Dec 43; 12-13 Feb 46; 27-28 Oct 48; 5-6 Mar, 26-27 Nov 50; 29 Apr-1 May 52
+Owae		Bagnall & Petersen (p. 38) place this on Helena Bay, Whangaruru Bay, presumably near the mouth of the Owai Stream which flows into the southwest corner of Helena Bay	13-17 Feb 36; 21-24 Jun, 26-30 Sep, 21-23 Dec 39; 7-8 Jan, 14-16 Aug, 20-22 Sep, 8-11 Oct 41; 18-21 Feb 42
+Owahanga River		North of the Mataikona River and apparently not to be confused with the settlement on the north side of the Mataikona River mouth	28 Nov 45; 28 Aug 46; 6 Jun 48; 1-2 May 49
+Oẁakau		On the Tutaekuri River near the point where the ascent of Kuripapango (Te Kohurau) began, but not located	14 Feb 52
+Oẁiorangi		Owiorangi appears on Arrowsmith’s 1850 map as on the west bank of the Waikare River near Warau, Urewera. This indicates a position near Otahuao	12 Jan 44
+Paharakeke	(a small wood)	Paharakeke Stream drains into Rangatea Lagoon near the southern end of Lake Wairarapa	6 Nov 45; 18 Mar 46
+Paharakeke Wood	near Patea	This locality does not appear in the Journal but in the list of 31 January 1853, and might possibly be a confusion with the Wairarapa wood of the same name. The specimen, 4257 Hymenophyllum, is not represented at WELT so no decision based on phytogeographic considerations can be made	
+Pahawa		The Pahaoa River on the Wairarapa coast	18 Mar, 22-24 Nov 45; 25-27 Feb, 8-9 Sep 46; 6-10 May, 16-19 Oct 47; 20-24 Apr, 4-7 Nov 48; 24-26 Apr 49; 16-19 Mar 50; 12-14 Apr 51; 10-14 Apr 52
+Pahiatua	near the R. Manawatu	Modern Pahiatua on the Mangatainoka River south of its junction with the Manawatu	This locality does not occur at all in the Journal, but appears fairly commonly in the lists after 1848
+Pahitaua		Arrowsmith’s 1850 map shows Pahitaua as close to the east bank of the Whakatane. Colenso travelled ENE to Pahitaua before turning southeast to Te Rangaataneiti, which would indicate Pahitaua as being in the vicinity of the hill now known as Rangiahua	10 Jan 44
+Paihia	Bay of Islands		Colenso was in residence here from 31 December 1834 until 12 June 1843
+Pakarae		… at the northern end of Whangara Bay, at the mouth of the Pakarae stream. (Bagnall & Petersen, p.136n) (about four miles south of Gable End Foreland)	8-9 Dec 41; 30 Oct 43
+Pakaraka		On the main highway between Kawakawa and Ohaeawai. Colenso described it as (Mr Edward Williams’) farm about 13 miles inland from Paihia	15 Apr 39
+Pakaraka	4 miles from Pihoi in the Ẁangarei district	In 1841, Pakaraka was reached from Pataua in half a day. From Pakaraka the Bay was crossed to Pohue and recrossed to Tamatarau. This suggests that Pakaraka was at the head of Whangarei Harbour, on the present site of Whangarei	10 Dec 39; 27-28 Sep 41
+Pakarau		Pakarau was reached in 2½ hours’ travelling northwest and west from Tapiri Assuming Tapiri and Matamata to be the same or contiguous places, Pakarau would have been in the vicinity of modern Morrinsville	
+Pakeaka	Te, Forest, nr. Mission Station, Hawkes Bay	Shown by Bagnall and Petersen (p 237) as being some two miles west of the mouth of the Tukituki River	
+Te Pakiaka	near Station, Ahuriri	Bagnall & Petersen (p. 237) show Pakiaka Bush on the approximate site of Mangateretere south of Whakatu	The name does not appear in the Journal, but first appears in the list of 22 December 1846
+Pakoẁai	Te Pakowai village –  near the 2 teeth	Bagnall & Petersen (p. 206) show Pakowhai at Black Head (Parimahu). Colenso, however, in an undated list, described it as near ‘the 2 Teeth’. Arrowsmith’s 1850 map shows the 2 teeth as about halfway between Porangahau and Cape Turnagain. Arrowsmith would appear to have confused the 2 Teeth with Cook’s Tooth	13 Feb, 22 Aug 46; 24-25 May, 5-6 Oct 47; 12-13 Jun, 28 Oct 48
+Pakuku		Bagnall & Petersen (p. 217n) suggest that this is the present Papuku Stream, south of Cape Turnagain	10-11 Mar 45; 16 Apr, 24-25 Oct, 29 Nov 45; 17-19 Feb, 26-28 Aug 46; 19-20 May, 9-11 Oct 47; 30-31 Oct 48
+Pakura	Dense forests near Ruatahuna	Not located	
+Palliser Bay		The deep, wide bay at the southern end of the North Island	19-25 Mar, 1-3 Apr, 6-11, 18-21 Nov 45; 2-7, 13-17 Mar, 11-16 Sep 46; 15-20 & 28 Apr-5 May, 21-27 Oct 47; 26 Apr-2 May, 8-13 Nov 48; 29 Mar-3 Apr 49; 17-19 Apr 51
+Pamateao		Described by Colenso as a desert beach and as a point 20 miles N. of Cape Palliser but the name has not been found on any maps including those of Arrowsmith	7 Apr 52
+Panekiri (Panekire)	Panekiri Range on the southern shore of Waikaremoana but not mentioned in the Journal		21-26 Dec 43
+Te Papa		Not located, but presumably on the northern Rangitaiki Plains	5-7 Dec 49
+Te Papa		Mission Station, Tauranga	5-12 Jan 38; 25-26 Jan 44
+Papakoẁatu		Arrowsmith’s 1850 map shows this on the east bank of the Whakatane, below the Waimana confluence	20 Jan 44
+Papakura plains		On the east shore of Manukau Harbour	1-2 Feb 44
+Paparaumu (Paparaaumu)	Bagnall & Petersen ( p. 38) show this north of Owae, in the approximate position of modern Mokau on the Whangaruru Harbour	The name does not appear on modern maps	24 Jun, 30 Sep-1 Oct, 23 Dec 39; 6-7 Jan, 16-17 Aug 41
+Parae		Appears on a few wrappings Not a locality but a Māori word meaning undulating or level country	
+Parangahau	Cook’s Straits	Probably a slip for the following	
+Parangarahu		Parangarahu was … on the flat before Baring Head, to the east of the Paiaka Stream (Bagnall & Petersen, p.219n)	
+Paremata Hill	A high, conical hill between Whangaruru & Waikare	Paremata, 1280 feet alt., is inland from Helena Bay, Whangaruru Harbour	16 Apr 35
+Paratetaitonga		The northern peak of the Ruapehu summit crater. Colenso appears to use the name interchangeably with Ruapehu	28 Nov 49
+Pareranui	Eastern side of Taupo plains	Pareranui Stream is one of the tributary streams of the Waipunga River east of Pohokura on the Taupo-Napier Highway	The locality would have been passed on or about 15 February 1847 and indicates that Colenso’s route lay west of the present highway
+Parewarewa	On the west bank of the Whakatane River, 1½ miles downstream from Tahunaroa		20 Jan 44
+Parikarangaranga	On the Turanganui River, Wairarapa	Pakarangaranga is a trig point to the north of the river about two miles from the junction of the Pirinoa and Whakatomotomo Roads	3 Apr 45; 29-30 Mar 49
+Parimahu		Black Head, on the East Coast south of Cape Kidnappers	6 Dec 43; 6-7 Mar, 1-2 Dec 45; 6 Mar 50; 27-28 Mar 51; 28 Apr 52
+Parinuiotera		Gable End Foreland, north of Poverty Bay	25 Jan 38; 8 Dec 41
+Paripokai	Nr. River Wangaehu, Taupo	Not located	
+Paroa Bay (Paro Bay)	On the south shore of the main channel of the Bay of Islands, and east of Russell		30 May, 3 Jul 36
+Parua		On Parua Bay, a deep bay on the north shore of Whangarei Harbour	2-4 Oct 41
+Patangata		On the bank of the Tukituki River, east of Waipawa	23-24 Apr, 20 Sep, 20 Oct 45; 28-29 Jan, 8 Apr, 24-25, 30 Jun, 5-6 Oct 46; 9, 13-14 Jan, 2-3, 25 Mar, 10-11 Sep, 27-29 Nov 47; 24 Mar, 22-23, 26-27 Sep, 16-18 Dec 48; 9 Mar, 16-21 May, 16-17 Oct 49; 4-6 Feb, 13-15 Apr, 15-16 Jul, 16-19 Nov 50; 9-11 Aug, 31 Oct 51; 17-19 Jan, 21 Sep 52
+Pataua	Pataua Creek, near Wangarei, E. Coast	At the southern end of Ngunguru Bay	27 Sep 41
+Patea	Western base of Ruahine range	The statement in In Memoriam ( p. 72) that two visits were made in 1852, the second in May, is not borne out by the Journal. The events described occurred on the February 1852 visit	23-24 Feb 47; 1-3, 6-7 Jan, 6-13 Dec 48; 22-27 Nov 49; 18-27 Oct 51; 19-24 Feb 52
+Pauanui (?Black Head)	Paoanui Point is north of Tuingara and thus considerably north of Black Head or Parimahu	Colenso appears to have mistakenly applied Cook’s name in the earlier instances	7 Dec 43; 6 Mar 45; 13-14 Jun 48
+Pepepe		B. Y. Ashwell’s Mission Station on the Waikato River. Colenso took an hour to travel by canoe from Ngaruawahia downstream to Pepepe, and Arrowsmith’s 1850 map shows it on the west bank well below the Waipa junction. Cowan (1922, illustration p.24-25) shows Ashwell’s station, Kaitotehe, opposite Taupiri. Pascoe (Exploration in N.Z. 1971, p.20) also refers to Pepepe Mission Station … Near Taupiri …	30-31 Jan 44
+Petane (Petani)	A few miles north of Ahuriri at the northern end of the old lagoon and at the mouth of the Esk River	The name, a rendering of Bethany, is a replacement for Te Kapemaihi. The change could possibly have taken place at Christmas 1848. The Native Teacher, Paul Toki, is named for both place names. Lambert ( p. 312) has another name, Kaiarero, as the old name for Petane, but does not mention Te Kapemaihi. Buchanan ( p. 168) cites yet another name, Oharua	30-31 Jan, 14-15, 18-19 Jun, 12-13 Dec 49; 11-12, 14-15 Jan, 9-10, 15-20 May, 17-18 Jun, 2-3 Oct, 20-21, 23-24 Dec 50; 1-3, 5-10 Mar, 2-4 Jun, 27-29 Sep 51; 13 Nov, 16-17 Dec 51; 10-13, 30-31 Jan, 5-7 Jun, 1-3 Jul, 11-12, 14, 26-27 Aug 52
+Piarere Ravine		On Lake Karapiro, Waikato River, where the river turns abruptly from north to west	21 Jan 42
+Pihoe (Pihoi)	Bagnall & Petersen ( p. 38) show this at the southwest corner of modern Whangarei		9-11, 14-17 Dec 39; 30 Sep 41
+Pikitanga	Ruahine Forest Pikitanga on R. Makororo	Not a locality name, but a Māori word meaning ascent, as of a mountain, in this case the Ruahines This is an interesting instance of Colenso’s bilingualism	
+Pipi	About a mile and quarter from Te Kape	Downstream from present-day Ruatahuna. Arrowsmith’s 1850 map shows it on the east bank of the Whakatane River	8-9 Jan 44
+Pirapirau	A small village in the Tarawera district (In Memoriam, p.34)	Not located. The Journal does not mention it	12-15 Feb 47
+Pirau	River, Tutaekuri	Not located Buchanan (Map 3) shows a locality Pirau on the stream flowing into Lake Oingo which might be that intended by Colenso	
+Te Pito		Te Pito Stream reaches the sea at Waikori Bluff, three miles south of East Cape	25-26 Nov 41
+Pitokuku		Pitokuku Point is at the southern end of the sand spit which forms the south head of Whananaki Inlet	7 Oct 41
+Pitoone		Modern Petone, at the northern end of Wellington Harbour	25-26, 30-31 Mar, 11, 13-17 Nov 45; 7-9, 11-12 Mar 46; 20, 23-28 Apr, 27-28, 30-31 Oct, 1-4 Nov 47; 3 May, 13-15, 17-18 May 48; 3-4, 7-9, 14-17 Apr 49
+Pohatupapa		This appears to be the same as the present locality of Blackhead, north of the promontory of that name, which identification is supported by Buchanan ( p. 168)	6 Dec 43; 8-9 May 49
+Te Pohue	Hawke’s Bay	On Highway 5 from Napier to Taupo, 29 miles from Napier	23 Apr 46; 29-30 Jan 49
+Te Poraiti		On the west shore of the Inner Harbour, Ahuriri, about opposite the entrance	16-18 Jun 45; 23 Jun 47; 17 Oct 48; 16 Jan 50; 29 Jun 52
+Porangahau		On the Porangahau River between Black Head and Cape Turnagain, about 50 miles south of Cape Kidnappers	4-6 Dec 43; 17-21 Apr, 22-24 Oct, 29 Nov-1 Dec 45; 13-17 Feb, 22-26 Aug 46; 20-24 May, 6-7 Oct 47; 9-12 Jun, 28-30 Oct 48; 5-8 May 49; 22-26 Nov 50; 28 Mar-1 Apr 51; 24-28 Apr 52
+Porokanae		A little village near Haruru, presumably on the Waitangi River, Bay of Islands	26 May 39
+Poroutaẁao	8 or 9 miles (north from Waiorongo and) about 2 miles (from Mataikona)	Not mentioned by Colenso on other journeys along this coast. It may be the same as Te Rerenga of Arrowsmith’s 1850 map	16 Nov 43
+Port Nicholson		Wellington Harbour	25-31 Mar, 11-17 Nov 45; 7-12 Mar 46; 3-17 Apr 49
+Porua	A steep hill on upper reaches of Wairua River, Ẁangarei	Porua, a hill near the west bank of the Wairua, northwest from Whangarei	25-26 Feb 36
+Poukawa	Ahuriri	Poukawa Lake lies to the west of the Tukituki River, 11 miles south of Hastings	
+Pounga	a little deserted village (on the Rangitikei River upstream from Otara, present Ohingaiti, but not located)		4-5 Dec 48
+Poureatua (Poureetua)	One hour’s walk to East Cape	Not now so named, but Bagnall & Petersen ( p. 66) show Poureatua on what is now Haumai Beach	17 Jan 38; 25 Nov 41
+Poutu		On the eastern shore of Lake Rotoaira, the small lake south of Lake Taupo	It is presumably the same village mentioned on 18-19 Feb 47; 29 Nov-1 Dec 49
+Poututu		Possibly to be equated with Potua Stream, three miles east of the Waihua River in northern Hawke’s Bay. A feature, Potutu, is marked three to four miles inland	30-31 Jul, 16 Aug 45
+Poverty Bay			26-29 Jan 38; 10-20 Dec 41; 24 Dec 44; 6-13 Aug 45
+Pua		On the Kawakawa River, downstream (?) from Otuihu. Presumably the modern Opua	28 Aug 36; 27 Jan 39
+Puehutai		Puehutai was on the Manawatu, just before the loop opposite Oringi (Bagnall & Petersen, p.233n) (a few miles south of Dannevirke)	2 Apr, 29-30 Sep 46; 29 Mar-1 Apr 47; 3 Mar, 1-4 Apr, 23-27 Nov 48 14-16 Mar 49; 6-9 Apr 50; 21-22 May 51; 18-22 Mar 52
+Puhangina River		The Pohangina River flows south along the western foothills of the Ruahine Range to join the Manawatu	29 Nov 48
+Pukaki		Pukaki Creek reaches Manukau Harbour at the eastern end of the runway of Mangere Airport	4 Feb 44
+Pukatea	Waikato River	Not located	28 Jan 42
+Te Puke (Tepuke)	Now a trig station and lookout point in the Waitangi (State Forest) National Reserve, Bay of Islands		5, 12 Jul 35
+Pukehore		On the coast between Tolago Bay and Gable End Foreland	25 Jan 38
+Pukekura Hill	Pukekura, nr. Eparaima	To the west of the Waipukurau – Porangahau Road, a short distance north of Wanstead	21 Apr 45
+Pukemaire		Pukemaire was on the west bank of the Waiapu River, slightly north by west of the present-day Port Awanui (Bagnall & Petersen, p.161n)	25-26 Oct 43
+Pukeokui	Ẁangarei	Not located but would appear to have been southwest of Whangarei, 1½ hours from the Wairua River. This may have been in the vicinity of Waiotama on Highway 14	22-23 Feb 36
+Puke Taramea		A prominent knob on the western ridge of the Ruahine Range adjacent to the Mokai Patea Ridge	27-28 Oct 51; 24-25 Feb 52
+Puketere	A small hill … Hukatere, about a third of the way north on Ninety Mile Beach	The spelling, Pukatere, appears on the Geological Sketch Map of the Northern District of … Auckland, 1866	
+Puketona		Bagnall & Petersen ( p. 38) show it at the junction of the Waiaruhe and Waitangi Rivers, Bay of Islands	10 Jan 36
+Te Puku		Te Puku is a headland a short distance south of Waimarama	8 Dec 43
+Tepukuotokotahu	the next village (after Hinukuku of the Waiomio valley)		Numerous visits are mentioned between September 1836 and October 1839
+Te Pukurua		Arrowsmith’s 1850 map marks Pukurua on the west bank of the Waimana River in an angle where the river’s course changes from northerly to westerly. Bagnall & Petersen ( p. 66) show it in the approximate position of modern Waimana	16-17 Jan 44
+Te Puna (Tepuna)	… was situated to the north of the Kerikeri Inlet, close to the site of the old mission station at Rangihoua	(Bagnall & Petersen, p.144n)	23-25 Jul 36; 17 Mar 40
+Te Puna		On the southern shore of Tauranga Harbour, west of Te Papa Station	26-27 Jan 44
+Punaruku (Penaruku)	On the road past Whangaruru Harbour		23 Dec 39; 11 Oct 41
+Punakitere River		Punakitere River flows northeast before turning east at Ngapuhi south of Kaikohe	2-? Jun 36
+Pungakoikoi		Presumably Kahokawa Beach at the northern end of Ninety Mile Beach	30 Mar -1 Apr 39
+Pupuaruhe		The pa on the west bank of the Whakatane River near the mouth	20-22 Jan 44
+Putauaki		Mt Edgecumbe, to the west of the Rangitaiki River, near Kawerau	22 Jan 44
+Te Ranga (The Ranga)	The high point, 1034 feet, on the ridge between Waikare and Whangaruru		11 Oct 41; 21 Feb 42
+Te Rangaataneiti		Te Rangaataneiti is on the ridge bounded by the Mahakirua and Waiawa Streams, between Maungapohatu and the Whakatane River	10 Jan 44
+Rangaunu River		Rangaunu Harbour, the large, mangrove-filled tidal inlet north of Kaitaia	3-4 Apr 39
+Rangitaike River		The Rangitaiki River, one of the main rivers of the Bay of Plenty. Although not mentioned in the Journal, the list of September 1847 mentions the headwaters to the east of Lake Taupo. Colenso thus encountered the river at its middle reaches (1842), its mouth (1844), and its headwaters (Feb. 1847)	6 Jan 42; 3 Jan 44; Feb 47
+Rangitikei River		Flows southwards from the Kaimanawa Range	24 Feb 47; 2-6 Dec 48; 23 Nov 49; 18 & 25 Oct 51; 18-19 Feb 52
+Rangitoto		A village very near Mokorau on the shore of Ahipara Bay at the southern end of Ninety Mile Beach	26 Mar 39
+Rangitukia		Near the mouth of the Waiapu Valley, East Cape	17-20 Jan 38; 26-29 Nov 41; 21-23 Oct 43
+Rangiwakaaitu Lake		Lake Rerewhakaaitu, the southernmost of the Rotorua lakes. The published versions appear to be errors, as the original spelling was Rerewakauitu	6-7 Jan 42
+Rangiẁakaoma (Rangiwakaoma)	Castle Point, on the Wairarapa Coast		15 Nov 43; 13-14 Oct 47; 1 Nov 48; 12-14 Mar 50
+Raparapahoe		Ninety Mile Beach, south of Arai, 3½-4 hours’ march from Arai	29 Mar, 2 Apr 39
+Ratoreka		Later referred to as Cook’s place it being the residence of a man named Cook, formerly in the employ of the mission. One of the villages near the mission station at Paihia, Bay of Islands	Mentioned several times between February 1835 and July 1839
+Ratu	about ½ a mile distant (from Pihoi, Whangarei)		10 Dec 39
+Raukawa		Now a road junction southwest of Hastings and west of the Raukawa Range	15-16 Sep, 27-28 Dec 47
+Rauporua (Rauporoa)	a village about 2 miles distant (from Kawakawa, Bay of Islands)	Not located	14 Oct, 30 Dec 38
+Cape Reinga			31 Mar 39
+Te Reinga		Te Reinga is at the junction of the Hangaroa and Ruakituri Rivers, the main branches of the Wairoa River, northern Hawke’s Bay	21-22 Dec 41
+Te Reke Manuka		Rekemanuka is marked on Arrowsmith’s 1850 map on the east bank of the Rangitaiki River, and would have been slightly north of modern Te Mahoe	22 Jan 44
+Reporua		Reporoa of modern maps, on the coast south of the Waiapu River mouth	20-21 Jan 38; 26 Oct 43
+Rimariki Island Off the south head of Whangaruru Harbour			27 Sep 39
+Rimuroa rivulet	nr. Waiohingaanga River	Not located	
+Ripo		From Colenso’s description, this could have been near the falls on the Wairua River, near Whangarei, but the name has not been located	24-25 Feb 36
+Rongoakiwa	road between Te Waipukurau and Te Witi	From the list of July 1846 Not located and not mentioned in the Journal	
+Rotoaira		The small lake to the south of Lake Taupo, lying between Pihonga and Tongariro Mountains. It now forms part of the Tongariro Power Scheme. The village mentioned by Colenso is presumably Poutu (q.v.)	18-19 Feb 47; [29 Nov-1 Dec 49]
+Te Rotoakiwa (Te Roto-a-kiwa lake)	Te Roto o kiwa lake is close to the Napier-Wellington highway	The railway line crosses it	13 Jul 52
+Te Rotoatara Lake		Drained in 1888 by Rev. S. Williams (Bagnall & Petersen, p.208n). It is now marked by a swampy area lying south of a line drawn from Otane to Patangata	4-5, 12-13 Feb, 23 Sep 45; 29 Jan 46; 13-14 Jan, 16 Dec 48
+Te Rotoatara village	On an island in Te Rotoatara Lake		23 Sep 45; 12-13 Jan, 13-15 Sep 47; 12-15 Jul 50
+Rotokura	A pool near Te Hawera		Mentioned in the list of 31 January 1853, but not located
+Rotorua		On a specimen, Nephrodium hispidum (WELT p.2603) in the bound volume of ferns. In this context, Colenso probably used Rotorua to refer to the lake rather than the modern town	The date would be from 8 to 12 January, 1842
+Ruahine range		That part of the North Island mountain range stretching from the Manawatu Gorge north to the Taihape-Napier highway	8-10 Feb 45; 24-26 Feb, 31 Dec 47; 8-11 Jan, 27-29 Nov, 13-14 Dec 48; 13-14 Dec 49; 16-17, 27-28 Oct 51; 24-26 Feb 52
+Te Ruaakauia River	Forest beyond Te Hawera village	From the list of September 1847 Not located nor mentioned in the Journal	
+Ruatoki	near R. Wakatane The modern Ruatoki (North)		
+Te Ruakaka	Ẁangarei Bay	On Bream Bay, about five miles south of Marsden Point, Whangarei harbour	16 Feb 42 Also mentioned in the list of 19 November 1844
+Ruakituri River		The western branch of the Wairoa River, northern Hawke’s Bay	22 Dec 41
+Ruamahanga River		Rises in the northeast Tararua Ranges and after flowing the length of the Wairarapa Valley enters Lake Wairarapa at the southeast corner before again flowing out to Lake Onoke at the coast. (24 Mar 45 as Wairarapa River)	4-5, 9 Apr 45; 24 Mar 46; 7 Apr, 8, 15 Nov 47; 11-12 Apr, 20-21 Nov 48; 22 Mar, 19 Apr 49; 25 Mar 52
+Ruapehu (Ruapahu)	Referred to in the list of June 1850	Colenso skirted the eastern base of this, the highest of the volcanic chain southwest of Lake Taupo	
+Ruatahuna (hill)		The ridge to the east of the Ruatahuna Valley, Urewera	28 Dec 43
+Ruatahuna		Arrowsmith’s 1850 map shows Ruatahuna as a hill and a stream, but not as a village. Colenso, however, clearly refers to a village, as well as a district. He placed the village about 4 miles from Mangatepa which would correspond with the present settlement of Ruatahuna	1-3 Jan 42
+Te Ruataniẁa	3 miles from Pipi downstream on the east side of the Whakatane River		9 Jan 44
+Te Ruataniẁa (village - Wairarapa)		Not located, but a morning’s travel north from Te Kaikokirikiri (Masterton). The location is possibly between Masterton and Mt Bruce. In the list of September 1847 it is mentioned as being at the head of the Wairarapa Valley. This is possibly the plantation Te Rua-o-Te-Taniwha near Te Kaikokirikiri mentioned by Bagnall (1954, p.4)	12 May 51
+Te Ruataniẁa Plain		Now known as the Takapau Plains (Bagnall & Petersen, p.208n). The low-lying area northwest from Waipawa to the base of the Ruahine Range and traversed by the Waipawa, Tukituki and Tukipo (Avoca) Rivers. Ruataniwha township (Te Ruataniẁa of Colenso) is a short distance west of Waipawa	5-7, 11 Feb 45; 27 Feb-1 Mar, 29 Dec 47; 30 Oct 51
+Ruaatoki (Ruatoki)	Ruatoki on the Whakatane River		16, 18-20 Jan 44
+Te Ruaẁakatorou		Arrowsmith’s 1850 map shows this on the east bank of the Waimana River, Bay of Plenty	17 Jan 44
+Runanga		A locality 36 miles southeast from Taupo near where the Waipunga River is first crossed by the Taupo-Napier Road	Referred to in the list of Jun 1850 but not mentioned in the Journal
+Schinde Island	Napier Now known as Bluff Hill, formerly Mataruahou, the hill overlooking Napier and Ahuriri Harbour		
+Table Cape		On the east side of Mahia Peninsula, northern Hawke’s Bay	2 Nov 43, but no landing
+Te Taha		A village on the western shore of Ahuriri Lagoon	12 Dec 43
+Te Taheke		Te Taheke was situated on the eastern side of Poukawa Lake. (Bagnall & Petersen, p.232n)	4 Feb 45; 29-30 Jan 46
+Tahora		A deserted village, scene of a massacre, a short distance N. of Wananake	
+Tauwhara Bay on the coast north of Whananaki Inlet is presumably the same place			22-23 Sep, 7-8 Oct 41
+Tahunaroa		Colenso describes this as on the east bank of the Whakatane, near Papakowatu, (a short distance downstream from the Waimana confluence)	20 Jan 44
+Taiamai (Taeamai)	Cowan (1922 - vol-1 p.38) shows Taiamai about halfway between Waimate and Ohaeawai, Bay of Islands	The European township which has appropriated the name (Ohaeawai) should properly be known as Toiamai (Cowan, s. c. p.68)	5 Feb 37; 19 Aug 38
+Taihoata River		A misspelling for Kaihoata	
+Taika		Otaika is about four miles south of Whangarei	12-14 Dec 39; 20 Jul 41
+Taikumikumi		This was on the Kawakawa River, Bay of Islands, between Opaohu and Kawakawa, about half a mile from the latter, and may have been Colenso’s customary landing place for his regular missionary visits to Kawakawa and Waiomio	10 Oct 40; 17 Jan 41
+Takamaitua	Between Cape Turnagain & Castle Point	Takamaitua was a creek one hour forty minutes south of Pakuku and would therefore be about halfway between Tautane and Akitio. (Bagnall & Petersen, p.217n)	Mentioned in the list of July 1846
+Te Takapau		Te Takapau was situated on the Ruatahuna Stream, not far south of Te Umuroa, Urewera. (Bagnall & Petersen, p.176) Arrowsmith’s 1850 map shows Te Takapau on a stream below a mountain Pukehuia, presumably Whakataka	
+Te Takapau	A small village on Pahawa River	Takapau is on the deep bend of the Pahaoa River at the confluence of the Waitetuna Stream just north of Hinekura	19-20 Apr 48; 19-20 Mar 50
+Takou		Takou Bay, north of the Bay of Islands	11 Apr 39
+Tamaki Creek		River Thames	Jan 43
+Tamaki River	Auckland	In 1843, the Firth of Thames included the Hauraki Gulf	The locality occurs on a specimen of Gymnogramme leptophylla at WELT and is also mentioned in the list of 10 May 1843
+Tamoki River (Tamaki)	The Tamaki River flows south of Tahoraiti to join the Manawatu by the rifle range at the end of the Totaramahanga Road, a few miles south of Dannevirke		17-18 Mar 52
+Tamatarau		Tamaterau, on the north shore of Whangarei Harbour east of Onerahi Peninsula. It was here that Colenso found the Tamil Bell	29-30 Sep-1, 2 & 4 Oct 41; 16-17 Feb,?Oct 42
+Te Tamumu		On the Tukituki River east of the confluence with the Waipawa	24-25 Mar 48; 12-13 Apr 50; 14-20 Jul, 20-23 Aug 52
+Tanenuiarangi		site of house now under freezing works (Buchanan p.161) (on the present site of Hastings)	1 Mar 45; 26 Jan 47; 8 Mar 49
+Tangiteroria	Mr Buller’s Station	On the Wairoa River, Northland, on the Dargaville-Whangarei Road and the site of Buller’s Wesleyan Mission. Not mentioned by name by Colenso	11-12 Feb 44
+Tangoiro		An hour’s march north of Waihirere Waterfall, (between Mawhai Point and Anaura Bay)	
+Tangoio		(Lagoon and River) On the coast of Hawke’s Bay, 14 miles north from Napier	15 Jun, 24-25 Jul 45; 5-7 Jan, 4-8 Jun, 25 & 27-30 Nov 46; 15-16 & 18-21 Jun, 28 Aug-1 Sep 47; 9-10 & 12-15 Feb, 10-14 Aug, 14-16 Oct 48; 20-23 Jan, 15-18 Jun 49; 12-14 Jan, 10-15 May, 18-21 Jun, 11-14 Oct, 21-23 Dec 50; 3-5 Mar, 4-5 Jun, 29-30 Jul, 29-30 Sep, 1-2 Oct, 10-11 & 13 Nov 51; 27 & 30 Jan, 7-9 Jun, 12-13 & 24-26 Aug 52
+Tapatahi		Inland from Waipiro (Open) Bay, East Coast. Arrowsmith’s 1850 map indicates it on the high land between Waipiro and Tokomaru Bays	22 Jan 38; 2 Dec 41
+Tapere	About 8 miles from the (Paihia) Station	On the way to Waikare, but not located	18 Sep 36; 1 Jan, 10 Sep 37; 25 Mar 38; 13 Jan 39
+Tapiri		Described by Colenso (Papers I, p.95) as the pa of the profess(in)g Chr(istian) Natives of Matamata and about a mile distant, (close to Waharoa), Thames Valley	20-21 Jan 42; 27-29 Jan 44
+Tapuaeharuru	Plains head of Wairarapa Valley	Not located nor mentioned in the Journal	
+Tapuata Forest	R. Manawatu	This name is preserved as a locality in Dannevirke County, a railway siding between Dannevirke and Woodville. Formerly called Tamaki according to Dollimore	Mentioned by Colenso in the list of 31 January 1853
+Tarare		On the east bank of the Rangitikei north of the Kawhatau junction (Bagnall & Petersen, p.292n). Colenso states that he followed the west bank	5 Dec 48
+Tararua Range		The southern end of the central North Island mountain chain, from the Manawatu Gorge southwards. Colenso’s acquaintance with the range was limited to the road, which was already under construction at the time of his first visit, over the Rimutaka Saddle	5- Nov 47; 17-18 Apr 49
+Tarawera	A well-fenced pa	On the upper reaches of the Kawakawa River but not located	1 Jun 36
+Tarawera Lake		Rotorua District	7 Jan 42
+Tarawera		On the Taupo-Napier Road at the Waipunga River. Bagnall & Petersen note ( p. 242n) that the village was situated on a terrace below the site of the old hotel	25-29 Apr 46; 12-15 Feb 47; 18-21 Feb 48; 25-29 Jan, 7-10 Dec 49; 5-8 Oct 50 The 1847 dates refer to Pirapirau, another village in the Tarawera district (In Memoriam, p.34)
+Taruheru		Poverty Bay. The name is preserved in a stream, a tributary of the Turanganui River. Porter (1974, p.83n) is unable to locate the village precisely	27 Jan 38
+Tauanui		The Tauanui River drains into the Ruamahanga near the outlet from Lake Wairarapa	6 Nov 45; 17-18 Mar, 16 Sep 46; 15 Apr 47; 24 May, 13-14 Nov 48; 29 Mar 49; 22 Apr 51
+Tauatepopo		part of Poukawa Block (Buchanan, p.181). Buchanan’s grid reference would place the village immediately north of Colin White’s Road at Te Hauke, ENE of Poukawa Lake	12-13 Mar, 9-10 Jul 52
+Taupo Lake			16-18 Feb 47; 1-4 Dec 49
+Taupo Plains		Roughly the Rangitaiki Plains to the east of Lake Taupo	15 Feb 47
+Tauranga		Bay of Plenty	5-12 Jan 38; 14-19 Jan 42; 24 Jan 44
+Tauranga Harbour		Bay of Plenty	19 Jan 42; 15-18 Oct 43; 24-27 Jan 44
+Tautane (Tautaane)	The Tautane River reaches the sea a mile or so from Cape Turnagain		10 Mar 45; 9 Oct 47; 8-9 Jun, 30 Oct 48; 4 May 49; 8-9 Mar 50; 2-3 Apr 51; 23 Apr 52
+Tauẁarenikau River		The river rises in the Tararua Ranges and flows between Carterton and Featherston before entering the northeast corner of Lake Wairarapa. The older spelling of Tauherenikau has been replaced by Tauwharenikau which conforms with Colenso’s spelling	18-19 Apr 49
+Taẁanaẁana	One of our old sleeping places…	On the wrapping of Colenso 4832, an hepatic from dense forest, nr. Te Hawera this name appears. It has not been located but as it was the overnight stop between Te Hawera and Te Kaikokirikiri, it was possibly in the vicinity of Ekatahuna	24 Mar 52
+Tauwenua (Hikurangi)		This corresponds either to Tauanui (1150 feet) or Tautoro No. 2 (1522 feet) to the west of the upper Punakitere River, and SSE of Kaikohe	5 Jun 36
+Tawera	WekaruatapuProbably in the vicinity of the present Matamau	There is also a Tawera just north of Mt Bruce, in the Wairarapa	
+Temateatai	Wangaruru Bay, Tamatateatai Point is a prominent peninsula on the west side of Whangaruru Harbour forming the northern side of Punaruku Estuary	The locality appears in an item 409 of an undated list	Oct 1841
+Thames River This included not only the present Thames Valley but also the Firth of Thames and Hauraki Gulf			
+Tihi		On the Ruamahanga River, three hours’ journey from Te Kaikokirikiri, but not located	12 Apr 48
+Tirohanga		Tirohanga Stream is a southern tributary of the Kawakawa River	16 Oct 36; 15 Jan, 12 Mar 37
+Titiokura		On Highway 5 from Napier to Taupo and at the saddle between Te Waka and Maungaharuru Ranges	23 Apr, 10 Dec 46; 11 Feb 47; 21 Feb 48; 9-10 Oct 50
+Titirangi		Walked to the Waimate (from Paihia), by way of Titirangi, 15 miles. Not located	6 Sep 36
+Toanga		In Poverty Bay and described as 3 miles from Kaupapa and 2 miles from Taruheru but not located. Porter ( p. 83n) was also unable to locate it precisely	27-29 Jan 38; 11-13 & 15 Dec 41;
+Tohora	E. Coast		Appears in the draft Journal of 22 May 1841 and in the list of 30 July 1844 and intended for Tahora (q.v.)
+Tohoranui		Tahoranui River drains into Taronui Bay at the south end of Takou Bay	11 Apr 39
+Toiti Village		Just short of the banks of the Waipa River (Bagnall & Petersen, p.127)	26-27 Jan 42
+Tokaroa	A peculiarly craggy rock	Honeycomb Rock? On the Wairarapa coast between Flat Point and the Pahaoa River	24 Nov 45
+Toki Village	on Wairua River, Ẁangarei	Three hours upstream from Aotahi and possibly in the vicinity of modern Titiko, although this is now on the Mangakahia River branch of the Wairoa catchment	23 Feb 35
+Tokomaru		Tokomaru Bay, East Coast	22-24 Jan 38; 2-4 Dec 41; 27 Oct 43
+Tolago Bay		Tolaga Bay. North of Poverty Bay	24-25 Jan 38; 7-9 Dec 41
+Tongariro	Base of	Colenso’s route lay to the east of the central volcanoes both on his southerly (1847) and northerly (1849) journeys	
+Totara		Totara North is on the west shore of Whangaroa Harbour	9 Apr 39
+Tourangatira		On the Kawakawa River but not located	1 Jun 36
+Tuarau Village	On Wangaroa River	Not located. It was presumably on the northern Whangaruru Harbour	15 Apr 35
+Tuatini		On Tokomaru Bay, East Coast	4 Dec 41; 27 Oct 43
+Tuhirangi		A small village three hours’ march south from Oroi and before Cape Palliser, but exact location not established	17 Apr 51; 7 Apr 52
+Tuhitarata		McMasters’ station on the Ruamahanga River close to the entrance to Lake Wairarapa	16 Sep 46; 24-25 May, 14 Nov 48; 22 Apr 51; 1 Apr 52
+Tuingara		A small cove a few miles south of Paoanui Point on the coast between Cape Kidnappers and Black Head	21-22 Aug 46; 4-5 Oct 47; 27 Oct 48; 5 Mar 50; 26-27 Mar 51; 1 May 52
+Tukituki River		The southernmost of the main central Hawke’s Bay rivers, flowing east then north to enter the sea at the southern end of Hawke Bay	1 Mar 45
+Tukituki Village		Probably Patangata (q.v.)	28 May 47
+Tukuwahine	A village about 3 miles from Te Kaikokirikiri (in an ESE direction)	Not located precisely, but was clearly close to Masterton Bagnall & Petersen ( p. 218) show it on the west bank of the Ruamahanga River and almost due east of Te Kaikokirikiri	
+Tunanui		Arrowsmith’s 1850 map marks Tunanui on the east bank of the Whakatane River downstream from the Waikare Stream junction. Bagnall & Petersen ( p. 66) show it on the west bank	15-16 Jan 44
+Tuparoa	Or, Te ari aẁai	South of Reporoa, East Cape, on the coast between Kouruamoa and Kaimoho Points	20-21 Jan 38
+Tupuaeharuru	Plains head of Wairarapa Valley	Not located	
+Turakirae	SW head of Palliser Bay		
+Cape Turakirae			The name occurs in the list of July 1846 but does not appear in the Journal
+Turanga		Poverty Bay	26-30 Jan 38; 10-20 Dec 41; 31 Oct 43; 6-13 Aug 45
+Turangakumu	nr. Tarawera	The Turangakumi Range is crossed by the Taupo-Napier Highway	The locality appears in the list of July 1848
+Turanganui River	Wairarapa	Flows northeastward to disperse into the swamp at the head of Lake Onoke	3 Apr 45; 19-23 Apr 51; 1-6 Apr 52
+Tutaekuri River		The northernmost of the main rivers of central Hawke’s Bay. It rises in the Kaweka Range and reaches the sea south of Napier. In Colenso’s time it turned north to discharge into the southern end of Ahuriri Lagoon	13 Feb 52
+Tutaimatai		Near the north end of Whangaruru Harbour, on the road to Russell	11 Oct 41; 21 Feb 42
+Tutangi	left (Waikino) and rowed to Tutangi	Not further located	1 Jan 37
+Tutukaka Harbour		About half a mile north of Ngunguru River	19 Dec 39; 24 Sep, 6 Oct 41; Oct 42
+Tututarata		Tututarata was on the range between Rangitaiki and the Mangawiri Stream (Bagnall & Petersen, p.176n quoting Best). A stream still bears the name	1-2 Jan 44
+Tuẁanui	by a small stream, Between Tangoio and Waikari	I can find no evidence of this …. But the coast here has been much altered by earthquake	7-8 Jan 46
+Tuwatapipi Stream		Not located but described as being between Waikare and Whangaruru Inlet	14-15 Apr 35
+Uawa River		The river flows north to south following the coastline of Anaura and Tolago Bays	24-25 Jan 38; 6-9 Dec 41; 28-30 Oct 43
+Uawa	a small village (apparently on the west shore of Palliser Bay)		26-27 Oct 47; 1-2 May 48
+Te Umukiwi	Tutaekuri		Occurs in the list of 31 January 1853 but not located and not mentioned by Buchanan
+Umuroa		This was on the way from Paihia to Paroa Bay, and is possibly to be equated with Oneroa Bay, Bay of Islands	3 Jul 36
+Te Umutaoroa		Some six miles north of Dannevirke on a west branch of the Mangatera Stream and close to the foothills of the Ruahine Range	14 Mar 49
+Te Unuunu		Te Unu Unu Stream reaches the sea at Flat Point, Wairarapa Coast	7 Sep 46; 3 Nov 48; 15 Mar 50; 14 Apr 52
+Upokohutia	A small clump of Karaka trees	Upokohutia would probably be the creek at the south end of Otahome flat, north of Waimimi (Bagnall & Petersen, p.219n)	
+Te Upokokirikiri	On the eastern shore of Lake Onoke, Palliser Bay	Arrowsmith’s 1850 map shows Poko kirikiri about half way along the shore	2 Apr 45; 4-6 Mar 46; 2 Apr 49
+Urewera		Although Colenso does not use this district name, it has been included as not only was Colenso the first pakeha to visit the area, but he was the first to map it, however, roughly, and the first to make botanical collections. For the present purposes the modern limits of the National Park are recognized	23 Dec 41-4 Jan 42; 19 Dec 43-16 Jan 44
+Uriti		Uriti Bay is on the east side of Pomare Bay, southeast of Russell, Bay of Islands	30 May 36
+Te Uruti		Uruti Point, south of the Whareama River, Wairarapa coast	14-15 Oct 47, although this is the only mention in the Journal, the name appears in the list of July 1846 and would have been passed on many occasions
+Uruhou		Arrowsmith’s 1850 map shows Uruhoa on the east bank at the mouth of the Wairoa River, Hawke’s Bay. Colenso places it three miles inland	15-18 Dec 43
+Wahanga	A river on the E. Coast, 20 miles N. of Mataikona	This version of Owahanga occurs in the list of 30 July 1844 The river is about nine miles north of Mataikona	
+Wahapu	The residence of Mr Mair	Te Wahapu Bay opens on to Veronica Channel northwest of Okiato, Bay of Islands Colenso mentions six visits between 1836 and 1839	
+Wahianoa (Wahienoa)	Wahieanoa, A spot on the hills where there was water	Between the Kaiwaka River and Titiokura, probably on the Maungaharuru Range	10-11 Feb 47; 15-16 & 20-21 Feb 48
+Waiapu River		The major river reaching the coast a few miles south of East Cape	17-20 Jan 38; 26 Nov-1 Dec 41; 21-23 & 25-26 Oct 43
+Waiariki		The Waiariki River joins the Waiotu River close to where Highway 1 crosses it from Hukerenui to Whangarei	19-20 Feb 36
+Waiariki	Cook’s Straits	Was situated at the mouth of the Waiariki Stream which flows south a mile to the west of Tongue Point on the southern coast of the Wellington Peninsula	8-9 May 48
+Waiaruhe		The Waiaruhe River flows north to join the Waitangi at Puketona, Bay of Islands	7 Sep 36
+Te Waiau River		From Colenso’s account, it is clear that this name was applied to the stretch of the Waikaretaheke River between the present Waiau and the Wairoa	18 Dec 43
+Waiaua		Waiaua Bay is at the northwest end of Takou Bay, north of the Bay of Islands	11 Apr 39
+Wai Haruru Stream		Waiharuru Stream is a tributary of the Hinemaiaia on the eastern side of Lake Taupo	16 Feb 47
+Waihi		Now known as Little Waihi at Town Point, Bay of Plenty. Arrowsmith’s 1850 map indicates Waihi further east than Colenso’s time intervals allow	
+Waihirere	A beautiful waterfall	Waihirere Stream is on the coast between Mawhai Point and Anaura Bay, East Coast	4 Dec 41
+Waiho River		The Waihou River, Northland, a main branch of the Hokianga	21 Mar 39
+Waiho River		Te Waihou River. The Waihou River, Thames	20 Jan 42; 27 Jan 44
+WaihoaWaihoa was approximately midway between Tuatini and Mawhai Point	the southern extremity of Tokomaru Bay (Bagnall & Petersen p.136n)	The Waihoa Stream reaches the sea towards the southern end of Tokomaru Bay	4 Dec 41
+Waihua	A few miles S. of Poututu	The Waihua River, northern Hawke’s Bay	17 Aug 45
+Te Waiiti (Te Waiti)	4 miles from Pihoi	The Te Waiiti Stream joins Limeburners Creek close to Highway 1, south of Whangarei	20-22 Feb 36; 11-12 & 14 Dec 39
+Te Waiiti		Te Whaiti on the Whirinaki River, inland Bay of Plenty	4-5 Jan 42; 30 Dec 43
+Te Waiiti District		The present Te Whaiiti, on the Whakatane River	
+Waikaha Stream		No longer marked on the maps but appears to be the stream draining the valley southeast of Pakipaki into the old course of the Ngaruroro in the vicinity of Havelock North. The stream has no doubt been absorbed by the drainage ditch system. Buchanan cites a stream in this vicinity	15 Nov 49; 17 Jan 52
+Te Waikamaka River	E. side of Ruahine	The Waikamaka River joins the Rangitikei north of the Mokai Patea ridge on the western side of the Ruahine Ranges	Colenso appears to have made an uncharacteristic slip in the reference which is in the list of 31 January 1853
+Waikaraka (Te Karaka (?) On Whangarei Harbour)	about 1½ miles from Tamaterau, and at the eastern base of Onerahi Peninsula		4 Oct 41; [17 Feb 42; Te Karaka]
+Waikare Lake		Lake Waikaremoana in the Urewera National Park	24-30 Dec 41; 20-28 Dec 43
+Waikare	Bay of Islands	On the Waikare River at the head of the inlet of the same name on the inner south shore of the Bay of Islands	
+Waikare River	Urewera	The stream flowing north from Maungapohatu to join the Whakatane Not mentioned by Colenso, but it is marked on Arrowsmith’s 1850 map and I have used it here as a reference to other place names	
+Waikaretaheke River		The outfall of Lake Waikaremoana. Colenso uses the name only for the stretch from the lake to the Waiau confluence	24 Dec 41; 18-20 Dec 43
+Waikari		A small village situated on a river of the same name. The Waikari River reaches Hawke’s Bay between the Mohaka and the Aropaoanui	14 Dec 43; 26-28 Jul 45; 8 Jan 46; 28-29 Jan 52
+Waikato River		The outlet for Lake Taupo and the major river of the North Island. Colenso also uses the name for what is now known as the Tongariro River at the southern end of Lake Taupo. He also applies the name Horotiu River for the stretch above the Waipa junction at Ngaruawahia	21 Jan & 28 Jan-1 Feb 42; 29-30 Jan (Horotiu)-31 Jan 44; 17, 19 Feb 47 (Tongariro); 1 Dec 49 (Tongariro)
+Waikino		Waikino Creek joins Waikare Inlet east of the confluence with the Kawakawa River, Bay of Islands	Twelve visits are recorded between May 1835 and July 1840
+Te Waimana River (Te Waimana District)	The Waimana River is a major eastern tributary of the Whakatane, Bay of Plenty		16-18 Jan 44
+Waimarama	About 15 miles south of Cape Kidnappers		8 Dec 43; 1-4 Mar, 3-4 Nov 45; 10-11 Feb, 18-20 Aug 46; 15-16 Jan, 27-28 May, 1-2 Oct 47; 15-16 Jun, 25-26 Oct 48; 10-15 May, 18-22 Oct 49; 2-4 Mar, 6-9 Jul, 28-29 Nov 50; 21-25 Mar, 6-8 Aug, 27-29 Dec 51; 4-6 May, 12-15 Jun, 17-18 Aug, 8-11 Nov 52
+Waimarara	A little stream in Palliser Bay	Bagnall & Petersen ( p. 218) indicate Waimarara Stream on the west shore of Palliser Bay, approximately in the position of the Little Mukamuka Stream. Older maps mark a stream approximately half way between Little Mukamuka and Cape Turakirae	19-20 Apr, 27 Oct 47; 18-19 May 48
+Waimarino	On the shore of Taupo Lake	The Waimarino River flows into the southeastern corner of Lake Taupo. The village may be the same as that later called Korohe (q.v.) by Colenso	17 Feb 47
+Waimata River		This river reaches the sea at slightly over half way travelling north from Akitio to Tautane on the Wairarapa Coast	22-23 Apr 52
+Waimate		Waimate North, on the Waimate River, west of the Bay of Islands and 3½ miles north of Ohaeawai. This was the first inland European settlement in New Zealand and Bishop Selwyn’s headquarters. Colenso records several visits between October 1835 and February 1840	He was in residence there in 1843-4
+Waimimiha	A small stream	The Waiamimi Stream south of Castle Point and a short distance north of the Whareama River on the Wairarapa coast	1-3 Nov 48
+Wainui		On a small bay of the same name east of Whangaroa Harbour, Northland	10 Apr 39
+Te Waiohingaanga River		Now known as the Esk, entering the sea at Petane between Tangoio and Napier	22 Apr 46; 9-10 Feb 47
+Te Waiokongenge		A camping spot Half-way down the (Ruahine) range, below Te Atuaomahuru on the east side	22 Feb 47
+Waiomio (Whaiomio)	A valley containing several villages (of which only Hinekuru and Tapukuotokoahu are named by Colenso)	In the first few instances he treats Waiomio as a village name. The Waiomio valley is almost due south of Kawakawa	From 1836, this district was Colenso’s main missionary responsibility and he made visits at approximately two-weekly intervals
+Waioreore		This is described as a small village on the route between the Wairua and Kawakawa Rivers. It would appear to have been near the head of the Waiomio Valley, possibly in the vicinity of Towai	26 Feb 36; 13 Feb 44
+Waiorongo	nr. Castle Point	Near the mouth of the Wakataki River a few miles north of Castle Point, on the Mataikona Road, Wairarapa Coast	15 Nov 43; 13-14 Mar, 26 Nov 45; 23-24 Feb, 3 Sep 46
+Waipa River		One of the main tributaries of the Waikato, joining it at Ngaruawahia	24 Jan 42; 30 Jan 44
+Waipahirere		A camping spot 2½ hours’ march south of Hukatere on Ninety Mile Beach, Northland	28-29 Mar 39
+Waipaoa River (Waipaua River)	Waipoua River, Our old sleeping place		
+The Waipawa River	Hawke’s Bay		7 & 11 Feb 45; 29-31 Dec 47; 29-31 Dec 49; 30 Oct 51
+Waipapa Stream		A stream named Waipapa joins the Waionepu River south of Maungatapere near Whangarei	22 Feb 36
+Waiparati	Te, near Tarawera	Not located, but Tarawera is the locality on the Taupo-Napier road	
+Waipawa River		A tributary of the Tukituki It rises in the Ruahine Range, is joined by the Makororo and flows into the main stream at Waipawa	
+Waipoua River	Head of Wairarapa Valley	Rises in the Tararua Ranges and joins the Ruamahanga at Masterton. Not mentioned in the Journal and appearing as item 691 in an undated list	
+Waipuakakahu	Half-way between Ẁangarei & Bay of Islands	The Waipuakakahu Stream joins the Waiotu River at Waiotu on the Kawakawa-Whangarei Road, 17 miles north of Whangarei	The date April 1843 appears on a specimen of Lomaria fluviatilis (WELT p.3320) and the locality also occurs in the list of 30 July 1844
+Te Waipukurau		The modern town of Waipukurau on the Tukituki in southern Hawke’s Bay	22-23 Apr, 20-21 Oct 45; 7-8 Apr, 25-30 Jun, 3-5 Oct 46; 9-12 Jan, 1-2 & 25-26 Mar, 11-13 Sep, 25-27 Nov 47; 25-28 Mar, 23-26 Sep 48; 9-12 Mar, 17-19 Nov 49; 11-12 Apr, 19-21 Nov 50; 24-27 May, 30-31 Oct 51; 13-16 Mar 52
+Waipupu		Waipupu Stream is south of the Whareama River and about two miles north of Riversdale Beach, Wairarapa coast	14 Mar 45; 24 Feb, 4 Sep 46; 11 May, 14 Oct 47; 3 Nov 48; 27-28 Apr 49; 14-15 Mar 50; 8-10 Apr 51; 15-17 Apr 52
+Waipureku		Bagnall & Petersen ( p. 237) show Waipureku between the Ngaruroro and Tukituki River mouths	26 Feb 51
+Wairarapa Bay (Palliser Bay)			
+Wairarapa Lagoon		It is clear that Colenso is referring only to the present Lake Onoke. His usual routes took him to the east or north of Lake Wairarapa and he appears never to have reached its shores	2 Apr 45; 4-6 Mar 46; 2 Apr 49
+Wairarapa Valley		Colenso includes the whole catchment of the Ruamahanga River from Mt Bruce to Palliser Bay	1-9 Apr, 30 Oct-6 Nov 45; 17-24 Mar, 16-23 Sep 46; 7-15 Apr, 5-15 Nov 47; 11-19 Apr, 13-20 Nov 48; 22-30 Mar 49; 19 Mar-1 Apr 50; 19 Apr-12 May 51; 25 Mar-6 Apr 52
+Te Wairere	A very high hill	The Wairere track was a well-known route across the Kaimai Ranges from Tauranga to Matamata. Some details of the track are given by Vennell (1969). The Wairere Falls are on the western side of the ridge. They are marked, together with the hill and the Ariki Falls further south, on Arrowsmith’s 1850 map	20 Jan 42; (27 Jan 44 - not mentioned in the Journal)
+Te Wairo	Our old potatoe plantation	Between the Kaiwaka River and Tarawera. This would appear to have been on or near the Mohaka River, the usual last stop before Tarawera	24-25 Jan 49
+Wairoa		The modern town of Wairoa in Northern Hawke’s Bay, although Colenso is probably referring to the river. He refers to the village as Uruhou (q.v.)	31 Jul-2 Aug 45
+Wairoa River		A major river of Northern Hawke’s Bay	15-18 Dec 43
+Wairoa River	Kaipara	Enters the northern arm of Kaipara Harbour	10-11 Feb 44
+Wairua River		The eastern branch of the Wairoa River, Northland	23-25 Feb 36; Oct 42; 12 Feb 44
+Wairua	On a small river	This was inland from Helena Bay, Whangaruru Harbour but has not been located. It is evidently not associated with the Wairua River of the previous entry	17-18 Feb 36
+Waitaatamakopiri		Not located	
+Waitahunui River		The Waitahanui River flows into Lake Taupo on the eastern shore north of Te Kohaiakahu Point	4 Dec 49
+Waitangi	Bay of Islands	The famous Treaty site opposite Russell Colenso records numerous visits between 1835 and 1840	
+Waitanoa		A pa south of the Tutaekuri, to the south-east of the present Allen Road. (Bagnall & Petersen, p.194n)	8 Jan 45; 28 Jan 47; 20 Jun 49
+Waitutuma	A small stream	The Waitetuna Stream rises on Mt Barton, Aorangi Mountains, and reaches the coast about three miles east of Cape Palliser	4-5 May 47
+Waiwetu		Waiwhetu, a suburb of Lower Hutt	18 May 48
+Te Ẁakaki		Whakaki, on the main road east of Wairoa, northern Hawke’s Bay	2-4 Aug 45
+Wakahau		Not located but about 6 miles from Otaika, Whangarei	13 Dec 39
+Ẁakamarino		Whakamarino was on the site of present artificial Lake Whakamarino at Tuai, below Waikaremoana	23-24 Dec 41
+Ẁakaraunuiataẁake	A potatoe plantation; Ẁakaraunuiotawake	This was on the coast between the Owahanga and Mataikona Rivers on the Wairarapa coast. On the last visit, Colenso notes it as now growing into a village, which, from earlier references, suggests that it had declined to a plantation before again being inhabited	11-12 Mar, 15 Apr 45; 19 Feb, 28-29 Aug 46
+Ẁakaruatapu		Whakaruatapu Stream flows west of Matamau to join the Matamau Stream to the south of the township in southern Hawke’s Bay Province. Te Ẁakatakapau. Described as one mile from Waitanoa and two miles from Te Awatoto, Hawke’s Bay, but not mentioned by Bagnall & Petersen or by Buchanan	28 Jan 47
+Ẁakataki		The Whakataki River enters the sea just north of Castle Point. The village of Waiorongo was near its mouth, and it is uncertain whether Colenso used alternative names for the same village or whether they were distinct places	11 Apr 45; 1-2 Jun 48; 7-8 Apr 51
+Wakatane	Bay of Plenty Modern Whakatane		
+Ẁakatane River		The Whakatane River, Bay of Plenty	Jan 42; 29 Dec 43; 8 Jan 44
+Ẁakatomotomo	A potatoe Plantation	Near the Turanganui River, Wairarapa	16 Sep 46; 24 May 48
+Ẁakatu		On the Ngaruroro River close to the confluence with Karamu Creek	21-22 May 49
+Wakaurekau River		On the following day (7th Jan, 1848) they left Te Awarua, but wind and rain halted them on the banks of the Whakarekou stream… (Bagnall & Petersen, p.269), (a stream on the western side of the Ruahine Range probably near the base of the Mokai Patea ridge) No such stream is marked on modern maps	
+Ẁakaurekou River		The Whakarekou River rises below Maroparea and Remutupo on the main Ruahine ridge and flows northwest to join the Rangitikei upstream from Awarua	7-8 Jan 48
+Ẁakauruhanga near Te Unuunu		To the north of Flat Point, Wairarapa Coast (Bagnall & Petersen, p.218)	10-11 Apr 51; 14 Apr 52
+Wakawitira		Whakawhitira on the Waiapu River, East Cape, about 10 miles from the mouth	18-19 Jan 38; 29 Nov-1 Dec 41
+Wananaki (Wananake Range)	Whananaki, on the north head of Whananaki Inlet, Northland		23 Sep, 7 Oct 41
+Wananake Bay	Whananaki Inlet, between Bay of Islands and Whangarei Harbour	The locality appears in the list of July 1841	Dec 39
+Wangaehu (Wangaihu)	Ẁangaehu	The Wangaehu River reaches the sea six miles north of Cape Turnagain and near Cook’s Tooth	10 Mar, 16-17 Apr, 24 Oct, 29 Nov 45; 17 Feb, 26 Aug 46; 20 May, 7-9 Oct 47; 4-5 May 49; 7-8 Mar 50; 1-2 Apr 51; 23-24 Apr 52
+Wangaehu River	Head of Wairarapa valley		
+Whangaehu River	a tributary of the Ruamahanga, the confluence being south of Masterton		
+Ẁangaehu River	Base of Tongariro	The Whangaehu River rises on the eastern side of Mt Ruapehu and flows southeast before turning southwest near Waiouru	28-29 Nov 49
+Wangai		The Whangae River enters the Kawakawa River near the mouth on the west side. The locality of Whangae is inland considerably to the west, beyond the watershed of the river Colenso gives several visits between 1835 and 1840, and is presumably referring to the river or to a village near its mouth	
+Wangaiti River	near Cape Turnagain		This name appears in the list of July 1846 but is not mentioned in the Journal and has not been located
+Ẁangaiẁakarere	A small village	Possibly to be identified with Whangaimoana, the stream which flows northwest parallel to the coast to reach Palliser Bay about two miles east of Lake Onoke	17 Mar 46
+Wangape		Whangape on the harbour of the same name between Herekino and Hokianga Harbours, to the south of the Ninety Mile Beach, Northland	23-25 Mar 39
+Wangara	A bold jutting promontory	Whangara is on the coast a few miles south of Gable End Foreland	26 Jan 38
+Ẁangarei		Modern Whangarei, but, as in other instances, it is not clear whether Colenso refers to a settlement or a district	Oct 41; Oct 42
+Wangarei Bay		Whangarei Harbour	8-9 Dec 39; 28-30 Sep 41; Oct 42
+Wangaroa Harbour		Whangaroa Harbour, the deep inlet between Doubtless Bay and Bay of Islands	9-10 Apr 39
+Wangaroa River		Now known as the Hangaroa River, a tributary of the Wairoa River, northern Hawke’s Bay. Arrowsmith’s 1850 map uses the same spelling as Colenso	21-22 Dec 41
+Wangaruru		On the east side of Whangaruru Harbour, south of the Bay of Islands	15-16 Apr 35; 10-13 Feb 36; 20 & 24-25 Jun, 26-30 Sep, 1 Oct 39; 17 Aug, 18 Sep 41
+Te Ẁarau Hill		Te Wharau is a ridge between the Whakatane and Waikare Rivers, not far from the junction. 13 Jan 44. Te Ẁarau. On the Wairoa River, upstream from Dargaville	11 Feb 44
+Ẁaraurangi		On the flat a quarter of a mile south of Glenburn Station homestead, behind Horewai Point, by the karaka grove. (Bagnall & Petersen, p.219n) (to the south of Flat Point, Wairarapa coast)	15-18 Mar, 24 Nov 45; 25 Feb, 7-8 Sep 46; 10 May, 16 Oct 47; 4 Nov 48; 26-27 Apr 49; 15-16 Mar 50; 11-12 Apr 51; 14 Apr 52
+Waraurangi Coast	Waraurangi, E. Coast	Bagnall & Petersen ( p. 213) describe it as being on the south side of the long shallow bay south of Flat Point, on the Wairarapa coast. There is a Māori cemetery at the mouth of the Waikekino Stream Bagnall and Petersen’s map ( p. 218) shows it slightly south of this bay, on the site of the Glenburn station	
+Warekahika		Wharekahika, Hick’s Bay, East Cape	16 Jan 38; 22-23 Nov 41
+Te Ẁareohinekiri	a sleeping-place a little below the top of the E. side of the (Ruahine) range		25-26 Feb 52
+WareoraWhareora	east of Whangarei		17-18 Dec 39; 4 Oct 41
+Warengarahu	A romantically situated hamlet on the side of a hill (between Opaoho and Kawakawa, Bay of Islands, but not located)		9 Feb 40; 21 Feb 41
+Ẁarepapa		The Wharepapa River enters Palliser Bay a mile or so to the west of Lake Onoke	13 Mar 46
+Wareponga		Whareponga is on the coast a few miles north of Waipiro Bay, between East Cape and Poverty Bay	22 Jan 38; 1-2 Dec 41
+Warerangi		Wharerangi is to the west of the old lagoon and opposite Napier	21-23 Jun 47; 17 Oct 48; 31 Jan, 19-20 Jun 49; 15-16 Jan 50; 29 Jun-1 Jul 52
+Wareturere		Wareturere was about four miles south-east of the site of the present town of Cambridge. (Bagnall & Petersen, p.138n)	21-24 Jan 42
+Warewatukahakaha		The plantations of Orauta	10 Nov 39
+Te Ẁataarakai		In the vicinity of Te Tamumu and Waipukurau but not located on modern maps nor mentioned by Buchanan	25 Mar 48
+Wataatamakopiri	Height above Kuripapango	Buchanan ( p. 198) so identifies a feature now marked as Te Whata No. 2 (2544 feet alt.) to the east of Timahanga on the Taihape-Napier Road. The name does not appear in the Journal but on a cryptogam packet	The date would be 16 October 1851
+Ẁataroa		Whatarua is on the upper Mangaaruhe River at the junction of the Ohuka, Matakuhia and Mangarewarewa Roads, east of Waikaremoana	23 Dec 41
+Watawata On the immediate banks of the Waipa		Not named by Colenso	27 Jan 42
+Watuma		Whatuma Lake is a mile or so southwest of Waipukurau. Previously spelt Hatuma The name appears on a few specimen labels	
+Te Ẁau		Te Whau, on the north shore of Manukau Harbour, at the western end of Blockhouse Bay	4 Feb 42; 5-6 Feb 44
+Wellington		The city on Wellington Harbour – at the southern end of the North Island. In Colenso’s time it would have been confined to the Te Aro flat area on the southern shore of the harbour at Lambton or Inner Harbour	26-30 Mar, 11-13 Nov 45; 9-11 Mar 46; 21-22 & 26-27 Apr, 28 Oct-2 Nov 47; 3-5, 9-13 & 15-17 May 48; 9-14 Apr 49
+Te Wera-a-te-Atua		… in the vicinity of the present-day Maungatautari pa (Bagnall & Petersen, p.138n). (near Cambridge)	23 Jan 42
+Te Werahi River		This river reaches Sandy Bay between Cape Reinga and Cape Maria van Dieman	30 Mar-1 Apr 39
+Whariti Whariti or Wharite is a peak in the southern Ruahine Range	six miles north of Woodville		
+Ẁirinake river (Wirinaki)	The Whirinaki is a tributary of the Rangitaiki River	Colenso does not name the river at Te Whaiti, recognizing it only lower down near the Rangitaiki	4-6 Jan 42; 30 Dec 43; 3-4 Jan 44
+Te Ẁiti		The Te Whiti clearing, a mile across, began just beyond the crossing of the Manawatu, some three miles from the present Takapau (Bagnall & Petersen, p.233n)	6-7 Apr, 2-3 Oct 46; 26-27 Mar 47; 28-29 Mar 48; 12-13 Mar 49; 23-24 May 51; 16-17 Mar 52

--- a/PlaceNames.txt
+++ b/PlaceNames.txt
@@ -1,5 +1,5 @@
 {A}
-*Te Ahiaruhe, Mr. Northwood’s Sheep’s Station. Bagnall and Petersen (p. 218) show this locality (“Ahieruhe”) close to the site of Carterton. There is a trig point and stream of this name on the south bank of the Ruamahanga River east of the Kokotau Road Bridge. 4-5 Apr 45; 19 Mar, 18 Sep 46; 12-13 Apr, 10 Nov 47; 29 May, 16 Nov 48; 29 Apr 51. 
+*Te Ahiaruhe, Mr. Northwood’s Sheep’s Station. Bagnall and Petersen (p. 218) show this locality (Ahieruhe) close to the site of Carterton. There is a trig point and stream of this name on the south bank of the Ruamahanga River east of the Kokotau Road Bridge. 4-5 Apr 45; 19 Mar, 18 Sep 46; 12-13 Apr, 10 Nov 47; 29 May, 16 Nov 48; 29 Apr 51. 
 Te Ahikereru. Arrowsmith’s 1850 map shows Te Ahikereru on the west bank of the Whirinaki, slightly upstream from the junction with the Okahu stream, Bay of Plenty. 30 Dec 43; 1, 5 Jan 44. 
 *Ahuriri, Hawke’s Bay. Originally the entrance to the lagoon, then the lagoon itself and used by Colenso as the name of the district, sometimes including the whole of the Heretaunga Plains. 
 *Akitio. About 15 miles south by coast from Cape Turnagain. 1-4 Dec 43; 15-16 Apr, 28-29 Nov 45; 19 Feb, 28 Aug 46; 18-19 May, 11 Oct 47; 6-8 Jun, 31 Oct 48; 2-4 May 49; 9 Mar 50; 3-4 Apr 51; 21-22 Apr 52. 
@@ -9,21 +9,21 @@ Aotea,(Barrier Island) Great Barrier in the Hauraki Gulf. 13 Oct 43.
 *Te Apiti, nearly opposite Bare Island; on coast S. of Bare Island; c. 8 miles S. of Bare Island. Te Apiti Stream reaches the coast due east of Elsthorpe and about two miles north of Kairakau. 11-12 Feb 46. 
 *Te Apiti, Banks of (Pahawa) River. This name occurs in the list of June 1850, item 2430. No such name is now marked on the Pahaoa River, but a homestead occurs on the Kaiwhata River, some four miles in a direct line from the Pahaoa headwaters. 
 Apungaotekura. Near Hallett’s Bay on the east side of Lake Taupo. This place is mentioned in In Memoriam (p. 37) but does not appear in the Journal. 16 Feb 47. 
-Arai (1). A sleeping place, a half hour’s walk from the following: 29-30 Mar, 1-2 Apr 39. 
-Arai (2), “a rocky headland.” Presumably Te Arai, the 53 foot high feature south of The Bluff, Ninety Mile Beach. 30 Mar 39. 
+Arai (1). A sleeping place, a half hour’s walk from the following. 29-30 Mar, 1-2 Apr 39. 
+Arai (2), a rocky headland. Presumably Te Arai, the 53 foot high feature south of The Bluff, Ninety Mile Beach. 30 Mar 39. 
 Arawata lake. From Colenso’s description and route, this would be one of the Lake Half – Swan Lake group near Ninety Mile Beach. 2 Apr 39. 
 Araẁata. The Arawhata Stream forms a conspicuous shingle fan on the coast about three miles south of Flat Point, Wairarapa coast. 14 Apr 52. 
 Te ari aẁai. Alternative name for Tuparoa. 20-21 Jan 38. 
 Te Ariuru, A large village in Tokomaru Bay. 
-Tokomaru Bay (Bagnall and Petersen p.109). Porter’s map (p. 621) marks Te Ariuru too far north. 2-4 Dec 41; 27 Oct 43. 
+Tokomaru Bay, (Bagnall and Petersen p.109). Porter’s map (p. 621) marks Te Ariuru too far north. 2-4 Dec 41; 27 Oct 43. 
 Aropaki. Arrowsmith’s 1850 map shows Aropaki on the west bank of the Whakatane River, opposite Warau hill. This corresponds to a position opposite the Mangatawhero stream mouth. 13-15 Jan 44. 
 *Aropauanui, Hawkes Bay. Near the mouth of the Aropaoanui River, north of Tangoio. Arapawanui is an old spelling. 13 Dec 43; 7-8 Jul, 9 Dec 46; 16-18 Jun, 30-31 Aug 47; 11-12 Feb 48; 13 Nov 51; 30 Jan 52. 
 *Te Atuaomaharu,topmost crag of Ruahine; Teatuaomahura The highest peak (5028 feet) of the northern Ruahine Mountains. 26 Feb 47; 28 Oct 51. 
 *Auckland. Jan (May?), 5-10 Oct 43; 15-22 Dec 44. 
 *Te Aute. About 8 miles north of Waipawa on the Napier/Wellington highway and railway, and about two miles west of Roto a kiwa Lake. 27 Feb, 13 Mar, 10-13 Jul 52. 
-Te Awaiti. “At the south of the Oterei” River (Bagnall & Petersen, p.219n), Wairarapa coast. 27 Feb 46; 19-20 Oct 47; 24-25 Apr, 7 Nov 48; 14-15 Apr 51; 8-10 Apr 52. 
+Te Awaiti. At the south of the Oterei River (Bagnall & Petersen, p.219n), Wairarapa coast. 27 Feb 46; 19-20 Oct 47; 24-25 Apr, 7 Nov 48; 14-15 Apr 51; 8-10 Apr 52. 
 *Te Awanga. Near the mouth of the Maraetotara Stream between Cape Kidnappers and the Tukituki River, Hawke’s Bay. 9 Dec 43; 29-30 Nov 50. Te Awaateatua. Buchanan (p. 133) notes a ford on the Ngaruroro River called Te Awaoteatua downstream from Fernhill. 8-9 Jul 52. 
-Awanui River,near Te Kawakawa, East Cape (list of 30 July 1844). Possibly an error for Awatere (q.v.), the river on which Te Kawakawa (modern Te Araroa) was situated. It does not appear to be associated with Port Awanui, a few miles down the coast from the mouth of the Waiapu River. 
+Awanui River,near Te Kawakawa, East Cape (list of 30 July 1844). Possibly an error for Awatere (q.v.), the river on which Te Kawakawa (modern Te Araroa) was situated - It does not appear to be associated with Port Awanui, a few miles down the coast from the mouth of the Waiapu River. 
 Te Awa o te atua. The old name for the lower reaches of the Tarawera River, reaching the sea at Matata, Bay of Plenty. 23 Jan 44. 
 *Te Awapuni. On the Waitangi River only a short distance from Colenso’s Mission Station in Hawke’s Bay. 9-12 Dec 43. 
 Awaroa. Awaroa Creek, Whangarei Harbour. 4 Oct 41. 
@@ -31,17 +31,17 @@ Awaroa. Awaroa Creek, Whangarei Harbour. 4 Oct 41.
 *Awatere River. Flows into Kawakawa Bay, East Cape. Mentioned in the list of 30 July 1844. 
 Awatoto, Te Awatootoo. On the coast of Hawke’s Bay, south of Napier. Colenso must have passed it on many occasions but it is mentioned in the Journal only on 3-4 July 52. 
 *Aẁea, East Coast. North of Cape Palliser, at the mouth of the Awhea River, a few miles south of Te Awaiti. 
-Aẁeanui, E. Coast. Probably to be equated with the Awhea River area, see below. 
+Aẁeanui, E. Coast. Probably to be equated with the Awhea River area..
 {B}
-Bare Island, E. Coast, a glen opposite. One mile offshore and about 15 miles south of Cape Kidnappers. 
-“Baridy Bay”. Baridy Bay is shown on Arrowsmith’s 1841 map as being the bay immediately south of Flat Point, Wairarapa coast. The name is possibly a corruption of Pararata, the name of a stream entering the Bay. Colenso, in the list of July 1846, puts the name in quotation marks. 
+Bare Island, E. Coast, a glen opposite. One mile offshore and about 15 miles south of Cape Kidnappers.. 
+Baridy Bay. Baridy Bay is shown on Arrowsmith’s 1841 map as being the bay immediately south of Flat Point, Wairarapa coast. The name is possibly a corruption of Pararata, the name of a stream entering the Bay. Colenso, in the list of July 1846, puts the name in quotation marks.. 
 Barrier Island. see Aotea
 Barton’s sheep station. see Kuraẁaẁanui. 
 *Bay of Islands. 1835-1844. 
 Bethany. Petane. 
 Black Head. See Parimahu. Colenso originally confused Cook’s place name with Paoanui Point. 
 {C}
-*Cape Kidnapper; Cape K.; C.K. Cape Kidnappers is the promontory at the southern end of Hawke Bay. 4, 26 May 46; 30 Jul-1Aug 50. 
+*Cape Kidnapper (Cape K.) (C.K.). Cape Kidnappers is the promontory at the southern end of Hawke Bay. 4, 26 May 46; 30 Jul-1Aug 50. 
 *Cape Maria van Diemen; Cape M. V. D. The western headland of the North Cape complex. Colenso was no nearer than 4-5 miles from the Cape proper. His collections labelled as from here would seem to use the name as a general locality. 30 Mar 39. 
 *Cape Palliser. The southernmost point of the North Island and the eastern boundary of Palliser Bay. 19 Mar, 21 Nov 45; 10-11 Sep 46; 4 May 47; 26-27 Apr, 8-9 Nov 48; 7 Apr 52. 
 Cape Reinga. One of the promontories of the North Cape complex. 31 Mar 39. 
@@ -61,12 +61,12 @@ Great Barrier Island. see Aotea.
 Haruru. At the head of the tidal flats on the Waitangi River, Bay of Islands. 26 May 39
 Haukawakawa river, Whangarei district; six miles northwest from Whangarei; Haukawakawa BayNot located precisely. No stream is now so named. 18-19 Feb 36; Oct 43. 
 Haumi. The Haumi River flows into Veronica Channel south of Paihia, Bay of Islands. 13 Apr 36. 
-*Te Hautotara. “Te Hautotara was east of Dannevirke, at the Mangatera-Manawatu Junction.” (Bagnall & Petersen, p.233n). 2-6 Apr, 30 Sep-2 Oct 46; 27-29 Mar, 22-23 Nov 47; 30-31 Mar 48; 9-10 Apr 50. 
-*Te Hawera. Modern Hamua, on the Woodville-Masterton highway, north of Ekatahuna. The name “Hawera” is still preserved in the district. 27-30 Mar 46; 3-6 Apr, 16-18 Nov 47; 5-10 Apr, 21-23 Nov 48; 17-21 Mar 49; 3-5 Apr 50; 14-16 May 51; 23-24 Mar 52. 
+*Te Hautotara. Te Hautotara was east of Dannevirke, at the Mangatera-Manawatu Junction. (Bagnall & Petersen, p.233n). 2-6 Apr, 30 Sep-2 Oct 46; 27-29 Mar, 22-23 Nov 47; 30-31 Mar 48; 9-10 Apr 50. 
+*Te Hawera. Modern Hamua, on the Woodville-Masterton highway, north of Ekatahuna. The name Hawera is still preserved in the district. 27-30 Mar 46; 3-6 Apr, 16-18 Nov 47; 5-10 Apr, 21-23 Nov 48; 17-21 Mar 49; 3-5 Apr 50; 14-16 May 51; 23-24 Mar 52. 
 *Hawkes Bay. Used by Colenso to indicate the bay itself and the district bordering the bay. 
 *Te Heiotepooro, Bleak crags, W. side (of Ruahine) (list of 31 January 1853). Not located: appears only in the plant lists. 
 Te Hekawa. Between Hick’s Bay and East Cape, east of modern Te Araroa. 16-17 Jan 43; 25 Nov 41. 
-*Herehere stream; Herehere plains. 	The Herehere Stream flows northwards through Havelock North to join the Karamu Creek. 16-17 Jan 52. Also mentioned in the lists of September 1847 and 31 January 1853. 
+*Herehere stream; Herehere plains. 	The Herehere Stream flows northwards through Havelock North to join the Karamu Creek. 16-17 Jan 52 Also mentioned in the lists of September 1847 and 31 January 1853. 
 Hereheretaunga, The landing place at the further extremity of the Lake (Waikaremoana). Presumably on Whanganui Inlet. Bagnall & Petersen (p. 170) spell Hereheretaua, but I have not found any other references. 
 Herekino. The northernmost of the harbours on Northland’s west coast. 25 Mar 39. 
 Herepunga. Arrowsmith’s 1850 map shows Herepunga on the right bank of the Waikaretaheke River, in northern Hawke’s Bay. 18 Dec 43. 
@@ -76,58 +76,55 @@ Heretaunga river. The Hutt River, flowing into the northern end of Wellington Ha
 Hikurangi (Tauwenua). See Tauwenua. 
 *Hikurangi, a high mountain capped with snow near the E. Cape. Mount Hikurangi, Raukumara Range. Not visited by Colenso, but an unnamed Māori was sent to bring back plants which are in the list of 30 July 1844. 
 Te Hinau. On the E. bank of the Ẁirinaki River, in the Te Ẁaiiti District, in the interior. Not noted by Best (1925) nor marked on Arrowsmith’s 1850 map, but clearly on the lower reaches of the Whirinaki near the junction with the Rangitaiki?. 4 Jan 44. 
-Te Hinau. Occurs on the ticket of Rumex flexuosus 4437, dated 16 Dec 51. The entry in the list of 31 January 1853 reads: “Rumex, growing with 4426; …i.e. “gravely shores, nr. Ahuriri.” This may be Te Hinu, the “pa on the Tukituki River” of Buchanan (p. 136). 
+Te Hinau. Occurs on the ticket of Rumex flexuosus 4437, dated 16 Dec 51. The entry in the list of 31 January 1853 reads: Rumex, growing with 4426; … (gravely shores), nr. Ahuriri. This may be Te Hinu, the pa on the Tukituki River of Buchanan (p. 136). 
 Hinemaia river. The Hinemaiaia Stream flows into the eastern shores of Lake Taupo at Hatepe. 16 Feb 47. 
 *Hinemokai village,On Waiau River, Hawke’s Bay. Arrowsmith’s 1850 map and Bagnall & Petersen (p. 66) show Hinemokai at the junction of the Waikaretaheke and Wairoa Rivers. 18 Dec 43. 
 *Hinuera valley. The present Hinuera is on the Rotorua branch railway between Matamata and Tirau. 21 Jan 42. 
-Hinukuku. “One of the nearest villages” of the Waiomio valley, Bay of Islands but not now traceable. Twenty identified visits between September 1836 and February 1840. 
-Hobson’s Harbour, Aotea. i.e. Great Barrier Island. Hobson’s Harbour no longer appears, but is probably an earlier unofficial name for Port Fitzroy. 13 Oct 43. 
+Hinukuku. One of the nearest villages of the Waiomio valley, Bay of Islands but not now traceable. Twenty identified visits between September 1836 and February 1840. 
+Hobson’s Harbour, Aotea. (Great Barrier Island). Hobson’s Harbour no longer appears, but is probably an earlier unofficial name for Port Fitzroy. 13 Oct 43. 
 Honurora. A large village on the seashore at the mouth of the Uawa River, Tolago Bay. 7-9 Dec 41. 
 *Hopekoko, A small stream…. Not identified. No streams of this name are now to be found between Parikanapa and Hangaroa River in Northern Hawke’s Bay. 21 Dec 41. 
 Horahora,near NgunguruThe Horahora River enters the sea at Ngunguru Bay, a short distance south of the mouth of the Ngunguru River. 17 Feb 42. 
 Horoera, A pa halfway between Te Hekawa and Poureatua, East Cape. Horoera marae is on the hillside above Horoera Point, to the west of East Cape. 25 Nov 41. 
-Hororoa, “about 3½ miles up the (Kawakawa) river.”Not now known. Ten visits noted between February 1835 and May 1840. 
-Horotiu River. On the one occasion when this name is used, Colenso uses it for the Waikato River above the junction with the Waipa at Ngaruawahia. This seems to have been customary. The New Zealand Gazette 70: 197ff. 26 Feb 1853 uses “Horatu”. Colenso appears to have reached the river somewhere south of Hamilton. 29 Jan 44. 
-Horotutu, Bay of Islands. “… the next beach along from Paihia towards the Waitangi River.” (Porter 111, n. 83). appears on a specimen of “Nephrodium thelypteris” in the bound volume of ferns at WELT. 
+Hororoa, about 3½ miles up the (Kawakawa) river.Not now known. Ten visits noted between February 1835 and May 1840. 
+Horotiu River. On the one occasion when this name is used, Colenso uses it for the Waikato River above the junction with the Waipa at Ngaruawahia. This seems to have been customary. The New Zealand Gazette 70: 197ff. 26 Feb 1853 uses Horatu. Colenso appears to have reached the river somewhere south of Hamilton. 29 Jan 44. 
+Horotutu, Bay of Islands. … the next beach along from Paihia towards the Waitangi River. (Porter 111, n. 83). appears on a specimen of Nephrodium thelypteris in the bound volume of ferns at WELT. 
 Houhora Harbour. A tidal inlet at the southern end of Great Exhibition Bay on the east coast of the Northland Peninsula. Mt Camel forms the eastern headland. 2 Apr 39. 
 *Huaangarua. This was on the site of Martinborough in Wairarapa (Bagnall & Petersen p.219n). The Huangarua River joins the Ruamahanga just north of the town. 4 Apr, 4-5 Nov 45; 18-19 Mar, 17-18 Sep 46; 13-14 Mar, 8-10 Nov 47; 14, 16-19 May, 15-16 Nov 48; 27-29 Mar, 19-23 Apr 49; 20-26 Mar 50; 23-29 Apr 51; 30-31 Mar 52. 
 *Huariki village, nr. Cape Palliser. Bagnall and Petersen (p. 219n) give the position as one mile north of Te Awaiti on the Wairarapa Coast. 18-19 Mar, 22 Nov 45; 27 Feb, 9 Sep 46; 6 May 47. 
-Te Huiakama,“A pa about a musket shot from Kaupapa.”i.e. Turanga or Poverty Bay. Curiously, Williams (Porter 1974) does not mention a pa of this name. 15 Dec 41
+Te Huiakama,A pa about a musket shot from Kaupapa (Turanga or Poverty Bay). Curiously, Williams (Porter 1974) does not mention a pa of this name. 15 Dec 41.
 Huiarau Range. The range of hills to the west and northwest of Lake Waikaremoana. 30 Dec 41-1 Jan 42; (28 Dec 43). 
 *Te Humenga, Palliser Bay. Te Humenga Point, the headland on the east side of Palliser Bay. 
 *Hurunuiorangi, Wairarapa valley. Bagnall and Petersen (p. 218) show Hurunuiorangi on the west bank of the Ruamahanga River almost opposite the confluence with the Tauweru River, near Carterton. A pa still occupies this position.  19-20 Mar, 18-19 Sep 46; 10 Nov 47; 18 Apr, 29-30 May 48; 26-27 Mar 50; 29-30 Apr 51. 
-*Hutt Valley; valley of the “Hutt”. The Hutt River flows into the northern end of Wel1ington Harbour. In addition to his numerous visits to Petone (Pitoone) at the southern end, Colenso twice travelled the length of the valley to reach the Wairarapa. 4 Nov 47; 17 Apr 49. 
+*Hutt Valley; valley of the Hutt. The Hutt River flows into the northern end of Wel1ington Harbour. In addition to his numerous visits to Petone (Pitoone) at the southern end, Colenso twice travelled the length of the valley to reach the Wairarapa. 4 Nov 47; 17 Apr 49. 
 {I}
 Te Ihooteata. Arrowsmith’s 1850 map shows this on the east bank of the Waimana River, Bay of Plenty. 17 Jan 44. 
 Ihuraua. Ihuraua Stream flows past Alfredton, 16 miles by road east of Ekatahuna. Although mentioned on 24 March 1846, Colenso never visited the village. 
-Ikaarangitauira, Sides of R. Tutaekuri. 
-Te Ikaarangitauira is placed by Colenso (Trans. N.Z. Inst. 11: p.85-6. 1879) on the banks of the Waitio River which now joins the Ngaruroro (not the Tutaekuri) at Ohiti by Runanga Lake. 
+Ikaarangitauira, Sides of R. Tutaekuri. Te Ikaarangitauira is placed by Colenso (Trans. N.Z. Inst. 11: p.85-6 1879) on the banks of the Waitio River which now joins the Ngaruroro (not the Tutaekuri) at Ohiti by Runanga Lake. 
 Iringataha. Arrowsmith’s 1850 map and Bagnall & Petersen (p. 66) show Iringataha on the north bank of the Waikaretaheke River. 18 Dec 43. 
 {K}
-Te Kahakaha. 
-Colenso gives the position as 3 miles NNE of Toreatai. Arrowsmith’s 1850 map shows it west of the northern end of the Maungapohatu ridge and upstream of the Waikare crossing. This suggests that it was not far from modern Pinaki. 12 Jan 44. 
+Te Kahakaha. Colenso gives the position as 3 miles NNE of Toreatai. Arrowsmith’s 1850 map shows it west of the northern end of the Maungapohatu ridge and upstream of the Waikare crossing. This suggests that it was not far from modern Pinaki. 12 Jan 44. 
 Kahumingi. Kahumingi is marked on the Masterton – Castlepoint Road several miles east of Tauweru, Kaumingi Stream, with its tributary of Biscuit Creek, flows into the Tauweru River. 30-31 Oct, 24 Nov 45. 
 *Kahuraanake,The hill, H. Bay; Kauranaki, near Bare Island. Kahuranaki (2119 feet alt.) is between the Maraetotara and the east bank of the Tukituki. Also spelt Kauranaki. 29-30 Dec 51. 
-Kahuwera stream. Not located. The main streams between Whareora and the Ngunguru River are the Taheke and Waitangi. 4-5 Oct 41
+Kahuwera stream. Not located. The main streams between Whareora and the Ngunguru River are the Taheke and Waitangi. 4-5 Oct 41.
 Kaihoata stream. Kaiwhata Stream north of Flat Point, Wairarapa coast (Bagnall & Petersen, p.213). 15 Mar 45; 4-7 Sep 46; 27 Apr 49 (as Taihoata); 10 Apr 51. Kaikohi. Modern Kaikohe, west of Bay of Islands. 8-9 Jan 36. 
 *Te Kaikokirikiri village, head of Wairarapa valley. Bagnall & Petersen (p. 218) place this on the present site of Masterton. 5-9 Apr, 31 Oct-4 Nov 45; 20-24 Mar, 19-23 Sep 46; 8-12 Apr, 13-15 Nov 47; 12-18 Apr, 17-20 Nov 48; 22-27 Mar 49; 27-31 Mar, 1 Apr 50; 30 Apr, 1-12 May 51; 25-30 Mar 52. 
-Kaikoura Stream,near the Rotoatara Lake. Buchanan (p. 139) so names a stream two miles north of Otane. He also notes Kaikora as “the original name for Otane.” 15-16 Dec 48. 
+Kaikoura Stream,near the Rotoatara Lake. Buchanan (p. 139) so names a stream two miles north of Otane. He also notes Kaikora as the original name for Otane. 15-16 Dec 48. 
 Kaiku, Cape Kidnapper. Not located but occurs in the list of July 1848. 
-Kaimatangi, 30 miles SW. from Ahuriri, inland. A trig point in the Ahimanawa Range near Tarawera might be intended if the direction is an error for “NW”. The name occurs in the list for July 1846. 
+Kaimatangi, 30 miles SW. from Ahuriri, inland. A trig point in the Ahimanawa Range near Tarawera might be intended if the direction is an error for NW.. The name occurs in the list for July 1846. 
 Kainganui. A hill described as on the north bank of the Waikaretaheke River, two miles from Iringataha and two miles from Herepunga. This appears to be the trig east of the McLean’s Road – Titirangi Road junction. 18 Dec 43. 
 Kaipara (harbour). On the west coast north of Auckland. 5 Feb 42; 7-10 Feb 44. 
-Kaipatiki, A small village about two miles distant from Paihia. 
-Kaipatiki Creek drains into the south arm of Waitangi Inlet. 22 Oct, 10 Dec 37; 1 Nov, 6 Dec 40; 15 Feb 41; 9, 25 Apr 55. 
+Kaipatiki, A small village about two miles distant from Paihia. Kaipatiki Creek drains into the south arm of Waitangi Inlet. 22 Oct, 10 Dec 37; 1 Nov, 6 Dec 40; 15 Feb 41; 9, 25 Apr 55. 
 Kairakau On the coast, 26 miles south of Cape Kidnappers, formerly Manawarakau (q.v.) Colenso uses both names. 
 Kaitaia. (Mission Station) Modern Kaitaia. 26-28 Mar, 4-8 Apr 39. 
-*Kaitara (forest)“Known to the early settlers as Morrison’s Bush” (Bagnall & Petersen, p.267n). The present locality of Morrison’s Bush is three miles south of Greytown. The forest bordered the Ruamahanga River between here and Martinborough (Huaangarua). 
-Kaiwa, Wangarei. Not located; mentioned in the list of 19 November 1844. 
+*Kaitara, (forest)Known to the early settlers as Morrison’s Bush (Bagnall & Petersen p.267n). The present locality of Morrison’s Bush is three miles south of Greytown. The forest bordered the Ruamahanga River between here and Martinborough (Huaangarua). 
+Kaiwa, Wangarei. Not located. mentioned in the list of 19 November 1844. 
 *Kaiwaka river. A tributary of the Waiohingaanga (Esk) River, Hawke’s Bay. 22-23, 30 Apr, 1 May 46; 23-24 Jan 49; 3-4, 10-11 Oct 50. 
 Kaiẁaraẁara. At the southern end of the western shore of Wellington Harbour. Reclamation has radically altered the shoreline in this area. This was the starting point of the track over the hills to the villages on Cook Strait, but Colenso would have passed it going to and from Wellington. 5? May 48; 7 Apr 49. 
 *Kaokaoroa; Te Kaokaoroa; plains, Kaokaoroa. The Kaokaoroa Range is west of the Tukituki River, opposite Opapa. The name occurs in a list of 31 January 1853. 
 *Te Kapa. Buchanan cites two localities of this name, one near Lake Roto-o-kiwa, the other near the Tukituki River on the other side of the Kaokaoroa Range. Colenso on one occasion associates the name with Kaokaoroa, so presumbably the second of Buchanan’s places is intended. 8-9 Mar 49. 
-Te Kape,¼ of a mile from Mangatepa (Ruatahuna). Best shows it on the east bank of the Whakatane River at the junction with the Mangaorongo Stream. Arrowsmith’s 1850 map shows it further downstream. 
-*Te Kapemaehe; Te Kapemaihi. Probably renamed Petani (Bethany) at about Christmas 1848. The Journal first mentions Petani in January 1849. 17-18 Jan, 16-18 Jun 45; 21-22 Apr, 3-4, 8-10 Jun, 21-25 Nov 46. 12-15 Jun, 27-28 Aug, 1 Sep 47; 22-23 Feb, 9-10, 14-15 Aug, 13-14 Oct, 16-17 Oct 48. 
+Te Kape,¼ of a mile from Mangatepa (Ruatahuna). Best shows it on the east bank of the Whakatane River at the junction with the Mangaorongo Stream. Arrowsmith’s 1850 map shows it further downstream..
+*Te Kapemaehe (Te Kapemaihi). Probably renamed Petani (Bethany) at about Christmas 1848. The Journal first mentions Petani in January 1849. 17-18 Jan, 16-18 Jun 45; 21-22 Apr, 3-4, 8-10 Jun, 21-25 Nov 46; 12-15 Jun, 27-28 Aug, 1 Sep 47; 22-23 Feb, 9-10, 14-15 Aug, 13-14 Oct, 16-17 Oct 48. 
 Te Karaka. Possibly Waikaraka (q.v.). 17 Feb 42. 
 Kareka Lake. Lake Okareka, Rotorua. 	7 Jan 42. 
 Kariawa. A pa in the vicinity of Porangahau. 7-10 Mar 45. 
@@ -135,29 +132,28 @@ Kariawa. A pa in the vicinity of Porangahau. 7-10 Mar 45.
 Kaukopakopa. Kaukapakapa, at the southern end of Kaipara Harbour. 8-12 Feb 42; 8-9 Feb 44. 
 Kaumingi River. See Kahumingi. 
 *Kaupapa, Poverty Bay. The first of the mission stations to be built on the Waipaoa River, Poverty Bay. Porter (p. 624) shows the station at the junction of the Waipara and Arai Rivers. See also Turanga. 10-20 Dec 41. 
-Kaupekahinga, “A native village on the banks of the Ruamahanga river.” Not located but presumably between Greytown and Martinborough. 19 Apr 49. 
+Kaupekahinga, A native village on the banks of the Ruamahanga river. Not located but presumably between Greytown and Martinborough. 19 Apr 49. 
 Kaurinui. Kaurinui Creek flows into the Bay of Islands near the south head land of Waikare Inlet. 24 Jan, 25 Sep, 20 Nov 36. 
 Te Kawakawa, Bay of Islands. Modern Kawakawa, on the river of the same name, which rises near Kaikohe and flows into the southern end of the Bay of Islands. Colenso made visits at two-weekly intervals for nearly the whole of his residence in the Bay. 
 *Te Kawakawa, East Cape. Modern Te Araroa. [16? Jan 38]; 23-25 Nov 41; 19-21, 23-25 Oct 43. 
 *Kawatau River, interior. Kawhatau River, a tributary of the Rangitaiki entering north of Mangaweka. The river is mentioned in the list of June 1850 and would have been crossed in November 1849. 
-Kaweka, Mt, ½ way between H. Bay and Taupo (“brought me by one of our surveyors”). The Kaweka Range, at the head of the Tutaekuri River. 
-Kereru (“Kerera”) lake. Lake Tauanui, about eight miles SSE of Kaikohe. So identified by Bagnall & Petersen and Colenso’s route leaves no doubt of the correctness of this conclusion. 5 Jun 36. 	
+Kaweka Mt, ½ way between H. Bay and Taupo (brought me by one of our surveyors). The Kaweka Range, at the head of the Tutaekuri River. 
+Kereru (Kerera) lake. Lake Tauanui, about eight miles SSE of Kaikohe. So identified by Bagnall & Petersen and Colenso’s route leaves no doubt of the correctness of this conclusion. 5 Jun 36. 	
 *Kerikeri. The locality on Kerikeri Inlet, Bay of Islands. 15 Jan, 2 May 35; 20-22 Apr,?-4 Nov 37; 22-24 Aug 38; 11-12 Apr 39. 
 Kerikeri waterfall, Bay of Islands. 
 Kerikeri Falls, on the River to the north of the town of Kerikeri. 
-Te Koau. A “watering place” on the coast south of Castle Point. This is possibly the Ngakauau Stream. 14 Mar 45. 
+Te Koau. A watering place on the coast south of Castle Point. This is possibly the Ngakauau Stream. 14 Mar 45. 
 *Kohinurakau. Bagnall & Petersen (p. 206) show this village on the west bank of the Tukituki River, southwest from Pakipaki. 12-20 Sep, 18-20 Oct 45; 27-28 Jan, 23-24 Jun, 6-7 Oct 46; 6-8 Jan, 9-10 Sep, 29-30 Nov 47; 21-22 Sep 48; 1-4 Jun, 22-25 Oct 49; 9-11 Jul, 15-16 Nov 50; 27-28 May, 8-9 Aug, 30-31 Dec 51; 19-20 Jan, 21-22 Jul,18-20 Aug 52. 
 Kohumaru. On a stream of the same name, a tributary of the Oruaiti River which flows into Mangonui Harbour. 9 Apr 39. 
 Kohuraanake. See Kahuraanake. 
-*Te Kohurau. Colenso’s description suggests Kuripapango, 4100 feet alt., between the Ngaruroro and the headwaters of the Tutaekuri Rivers. This is also borne out by Buchanan (p. 142). 
-16 Feb 52. 
-Kopau River, “the upper part of the Kawakawa.”Possibly the Pokapu Stream, a southern tributary of the Kawakawa catchment. 1-2 Jun 36. 
+*Te Kohurau. Colenso’s description suggests Kuripapango, 4100 feet alt., between the Ngaruroro and the headwaters of the Tutaekuri Rivers. This is also borne out by Buchanan (p. 142). 16 Feb 52. 
+Kopau River, the upper part of the Kawakawa.Possibly the Pokapu Stream, a southern tributary of the Kawakawa catchment. 1-2 Jun 36. 
 *Te Kopi. On the east side of Palliser Bay, just north of the mouth of the Putangirua Stream. 20-24 Mar, 2-3 Apr, 6-10 Nov, 18-21 Nov 45; 2-4 Mar, 13-17 Mar, 11-16 Sep 46; 15-19 Mar, 30 Apr-4 May, 22-26 Oct 47; 27 Apr-1 May, 19-24 May, 9-13 Nov 48; 30 Mar-2 Apr 49; 17-19 Apr 51; 6 Apr 52. 
 Korohe. At the southeast corner of Lake Taupo. It is possibly the same as Waimarino of the 1847 visit. 1-3 Dec 49. 
 Kororareka. Modern Russell, Bay of Islands. Visits at approximately monthly intervals were made for most of Colenso’s residence in the Bay. 
-Kotere; Kotore. “Distant about 4 Miles” from Kawakawa but not located. 15 Sep, 13 Oct 39. 
-*Te Kotipu Wood. Reached an hour after leaving “the head of the Mohaka River” i.e. Taharua River. This suggests that the wood was at the base of Te Iringa (4073 feet alt.) in State Forest 90. 
-Te Kotukutuku. Not located. Colenso describes it as being “at the head of the Wairarapa valley” and “on the edge of the river, and entrance to the long forest.” Assuming the river to be the Ruamahanga, the vicinity would appear to be Mt Bruce, north of Masterton. 12-13 May 51. 
+Kotere; Kotore. Distant about 4 Miles from Kawakawa but not located. 15 Sep, 13 Oct 39. 
+*Te Kotipu Wood. Reached an hour after leaving the head of the Mohaka River (Taharua River). This suggests that the wood was at the base of Te Iringa (4073 feet alt.) in State Forest 90. 
+Te Kotukutuku. Not located. Colenso describes it as being at the head of the Wairarapa valley and on the edge of the river, and entrance to the long forest. Assuming the river to be the Ruamahanga, the vicinity would appear to be Mt Bruce, north of Masterton. 12-13 May 51. 
 *Kowhaia River, dense forest near Manawatu. Not located. The name appears in the list of June 1850. 
 Te Kupenga. Bagnall & Petersen (p. 175 & 66) place Te Kupenga on the Rangitaiki River upstream from Te Rekemanuka, but Arrowsmith’s 1850 map shows it slightly downstream. 23 Jan 44. 
 Kuraẁaẁanui,Mr Barton’s sheep station. The Whawhanui River reaches the sea at White Rock, Wairarapa coast. 19 Mar 45; 2 Mar 46; 5 May 47; 21 Oct 47. 
@@ -171,8 +167,8 @@ Maketu. At Town Point, Bay of Plenty. 24 Jan 44.
 *Manawatu River; District. The main river draining the eastern side of the southern Ruahine Ranges. Colenso knew this river only on its eastern reaches, as he never entered the Gorge. 
 *Mangahane River; Mangohane River. The Mangaohane River rises on Otupae, the northern outlier of the Ruahine Ranges, and enters the Rangitikei River. 17 Oct 51; 18 Feb 52. 
 Manga-a-noka River. Possibly the Mangaone River which flows north from headwaters east of Ekatahuna. 27 Mar 46. 
-*Mangamako,“a little wood” near the Rangitaiki River. Not otherwise identifiable. 6 Jan 42. 
-Mangamauka, “a small rivulet.” Mangamauku Stream is a tributary of the Waikaretaheke River, entering it on the north side near Rosskeen. 19 Dec 43. 
+*Mangamako,a little wood near the Rangitaiki River. Not otherwise identifiable. 6 Jan 42. 
+Mangamauka, a small rivulet. Mangamauku Stream is a tributary of the Waikaretaheke River, entering it on the north side near Rosskeen. 19 Dec 43. 
 *Mangaonuku River. On the edge of Ruataniwha (Takapau) plains. The river flows south to join the Waipawa River to the west of the town of Waipawa. 5-7 Feb 45; 29 Dec 47. 
 Mangare, Wangarei. A Mangere Stream joins the Wairua River near Kokopu west of Whangarei: Colenso’s village was probably on this stream. 25 Feb 36. 
 *Mangarewa River. Rises on the Mamaku Range and flows northeast to join the Kaituna in the Bay of Plenty. 13 Jan 42. 
@@ -181,14 +177,13 @@ Te Mangaroa River. The Mangaroa River which flows north through Whitemans Valley
 *Mangatainoka River. Rises in the Tararua Ranges near Ekatahuna and flows north past Pahiatua to join the Manawatu near the Gorge. 30 Mar 46; 16-17 May 51. 
 *Mangataẁainui River. This is a northern tributary of the Manawatu between Norsewood and Matamau. 6 Apr 46; 10-11 Apr 50. 
 Mangataẁiri. The Mangatawhiri Stream joins the Waikato River above Mercer. 31 Jan-1 Feb 44. 
-*Mangatepa. “on the Mana-o-Rongo Stream in the Ruatahuna Valley.” (Bagnall & Petersen p.120 sub Mana-te-pa). See also Ruatahuna. 3 Jan 42; 8 Jan 44. 
+*Mangatepa. on the Mana-o-Rongo Stream in the Ruatahuna Valley. (Bagnall & Petersen p.120 sub Mana-te-pa). See also Ruatahuna. 3 Jan 42; 8 Jan 44. 
 Mangatété. Probably Mangatoetoe, near Kaiaka. 8 Apr 39. 
 Mangati Beach. Not located but presumably one of the beaches near the Mimiwhangata Peninsula. 20-21 Dec 39. 
 *Mangatuna. On the Uawa River, inland from Marau Point, between Anaura and Tolago Bays. 6-7 Dec 41. 
 *Mangaiwai. Mangawhai Harbour or Estuary is about three miles south of Bream Tail. 14 Feb 42. 
-Mangaiwata, A “fearful pass”. The Mangawhata Stream follows the line of the Taupo-Napier Road (Highway 5) from Titiokura Summit to the Mohaka River. The “pass” was a dangerous crossing of the stream. 23, 30 Apr 46; 11 Feb 47. 
-Mangaẁero, “a small village about four miles from Mr Stack’s Rangitukia.”
-Bagnall & Petersen show it on the Waiapu river upstream of Rangitukia and Pukemaire, but Arrowsmith’s 1850 map shows it WNW of Rangituklia! 23 Oct 43. 
+Mangaiwata, The Mangawhata Stream follows the line of the Taupo-Napier Road (Highway 5) from Titiokura Summit to the Mohaka River. The pass was a dangerous crossing of the stream (A fearful pass). 23, 30 Apr 46; 11 Feb 47. 
+Mangaẁero, a small village about four miles from Mr Stack’s Rangitukia. Bagnall & Petersen show it on the Waiapu river upstream of Rangitukia and Pukemaire, but Arrowsmith’s 1850 map shows it WNW of Rangituklia!. 23 Oct 43. 
 Mangohane River. See Mangahane River. 
 *Mangungu. The Wesleyan mission station on the Hokianga River, about 25 miles from the heads; on the south bank of the Waihou River near the confluence with the Mangamuka River. 21-22 Mar 39. 
 *Manukau Bay. Modern Manukau Harbour. 1-4 Feb 42; 10 May 43; 1, 5 Feb 44. 
@@ -197,35 +192,35 @@ Maraetai,(Maunsell’s Mission Station). On the south bank close to the mouth of
 *Maraetaha River, H. Bay. The name occurs only once, and that amongst specimens from the vicinity of Kahuranaki (list of June 1850). It is probably an error for Maraetotara, which river flows past the foot of Kahuranaki. 
 *Maraetotara River, at base of Kahuranake Hill. Enters the sea east of the Tukituki River. The name occurs in the list of 31 January 1853. 
 Maramanui River. This name is not now recognized. Colenso appears to apply the name to the Wairua River above the falls. 25 Feb 36. 
-Maramatitaha, “a high precipitous & very dangerous cliff.” Apparently the cliffs at the eastern end of Whangaimoana Beach, Palliser Bay. 3 Apr 45. 
+Maramatitaha, a high precipitous & very dangerous cliff. Apparently the cliffs at the eastern end of Whangaimoana Beach, Palliser Bay. 3 Apr 45. 
 Marumaru. Marumaru is shown on Arrowsmith’s 1850 map as being on the Whakatane River downstream from the junction with the Waikare Stream. Bagnall & Petersen (p. 66) show it in the angle between the two streams. 15 Jan 44. 
-Maruteangi, “on the E. bank of the Wakatane river … about 12 or 14 miles from Pipi.” Arrowsmith’s 1850 map shows Maruteangi at the beginning of Colenso’s route to the villages of Maungapohatu. Bagnall & Petersen (p. 66) mark Omaruteangi at the junction of the Whakatane and a stream from Maungapohatu, presumably the Manangaatiutiu. 9-10 Jan 44. 
-Mata, “Mr Monro’s residence on the N. bank of the (Hokianga) River.” Te Mata Point near Pupuwai Creek, Hokianga Harbour. Drury (1853, p.870) mentions “an Englishman’s house (Munro)” at the point. 22-23 Mar 39. 
+Maruteangi, on the E. bank of the Wakatane river … about 12 or 14 miles from Pipi. Arrowsmith’s 1850 map shows Maruteangi at the beginning of Colenso’s route to the villages of Maungapohatu. Bagnall & Petersen (p. 66) mark Omaruteangi at the junction of the Whakatane and a stream from Maungapohatu, presumably the Manangaatiutiu. 9-10 Jan 44. 
+Mata, Mr Monro’s residence on the N. bank of the (Hokianga) River. Te Mata Point near Pupuwai Creek, Hokianga Harbour. Drury (1853, p.870) mentions an Englishman’s house (Munro) at the point. 22-23 Mar 39. 
 Te Mata. A sulphur spring between the Whakatane and Rangitaiki Rivers. 22 Jan 44. 
 Te Matau-a-maui. Cape Kidnappers. Colenso also applies the name to the ridge leading to the Cape. 8 Dec 43. 
-Te Matai. Arrowsmith’s 1850 map shows Te Matai on the south bank of the “Waikaretaheki” River, upstream from the confluence with the Waiau. Bagnall & Petersen (p. 66) show it on the north bank opposite the confluence. Colenso’s description favours the Arrowsmith position. Matai is a modern location on the south bank downstream from the confluence. 19 Dec 43. (Bagnall & Petersen p.169 give Colenso’s arrival as the 18th). 
+Te Matai. Arrowsmith’s 1850 map shows Te Matai on the south bank of the Waikaretaheki River, upstream from the confluence with the Waiau. Bagnall & Petersen (p. 66) show it on the north bank opposite the confluence. Colenso’s description favours the Arrowsmith position. Matai is a modern location on the south bank downstream from the confluence. 19 Dec 43. (Bagnall & Petersen p.169 give Colenso’s arrival as the 18th). 
 *Mataikona. The Mataikona River enters the sea a short distance north of Castle Point. Nov 16-1 Dec 43; 12-13 Mar, 11-15 Apr, 25-29 Oct, 26-28 Nov 45; 19-23 Feb, 29 Aug-3 Sep 46; 13-18 May, 11-13 Oct 47; 2-6 Jun, 31 Oct-1 Nov 48; 28 Apr-1 May 49; 9-12 Mar 50; 4-7 Apr 51; 17-21 Apr 52. 
 Matamata. Thames Valley. The village of Colenso’s day was further north than modern Matamata, in the vicinity of Waharoa. 20-21 Jan 42. 
-*Matapouri. Matapouri is about one mile south of Sandy Bay. 19 Dec 39; 23-24 Sep 41; 6-7 Oct 41; Oct 42. December 1837 and March 1841 are mentioned in Icones Plantarum 6: t. 567. 1843. 
-*Matarauẁi, “near Cape Kidnapper; Mataraua.” Presumably the same place as Matarauwe on Bagnall & Petersen’s map (p. 206) and located about 8 miles south of Cape Kidnappers. 4 Dec 45; 10 Feb 46; 17-18 Oct 49; 21 Mar 51. 
+*Matapouri. Matapouri is about one mile south of Sandy Bay. 19 Dec 39; 23-24 Sep 41; 6-7 Oct 41; Oct 42 (December 1837 and March 1841 are mentioned in Icones Plantarum 6 t 567 1843). 
+*Matarauẁi, near Cape Kidnapper; Mataraua. Presumably the same place as Matarauwe on Bagnall & Petersen’s map (p. 206) and located about 8 miles south of Cape Kidnappers. 4 Dec 45; 10 Feb 46; 17-18 Oct 49; 21 Mar 51. 
 Mataruahou. The headland of the Bluff Hill, Napier, now overlooking the Port of Napier. 12 Dec 43. 
 Te Matata. Bay of Plenty. Colenso’s description indicates that the Rangitaiki River at this time reached the sea to the west of its present mouth. This is confirmed on Arrowsmith’s 1850 map on which the Rangitaiki and Tarawera Rivers have a common mouth. Matata is described as on the south bank and a position east of the modern town is indicated. 23 Jan 44. 
-Matatoto, “our old sleeping place.” On the Makaroro River, and probably close to the confluence with the Waipawa. 29-30 Oct 51. 
-Matatu, “a small stream.” “Two and a quarter hours’ march from Huaangarua on the way to Te Ahiaruhe.” Not further identified, although Porter (p. 421n quoting Bagnall) refers to “the Matatu track” up the Wairarapa Valley. 19 Mar 46. 
+Matatoto, our old sleeping place. On the Makaroro River, and probably close to the confluence with the Waipawa. 29-30 Oct 51. 
+Matatu, a small stream. Two and a quarter hours’ march from Huaangarua on the way to Te Ahiaruhe. Not further identified, although Porter (p. 421n quoting Bagnall) refers to the Matatu track up the Wairarapa Valley. 19 Mar 46. 
 Matauri. On Matauri Bay, opposite the Cavalli Islands, Northland. 10-11 Apr 39. 
-Matauẁi. Matauwhi Bay is immediately to the south of Kororareka Bay; the town of Russell extends southwards to the beach. Bagnall & Petersen’s map (p38) spells it “Matahi”. 4 Jun 37. 
-Matuku. “The actual site of Matuku, later known as Kohimarama, is on the western point of the long razor-backed ridge, on the eastern knob of which is the Matuku trig. It is situated on Mr. J. Duncan’s ‘Hiwera’ station.” (Bagnall & Petersen, p.257n). The pa site is now marked on the latest edition of the map. 23-24 Feb 47; 3-6 Jan, 6-12 Dec 48; 23-27 Nov 49; 18-25 Oct 51; 19-23 Feb 52. 
+Matauẁi. Matauwhi Bay is immediately to the south of Kororareka Bay; the town of Russell extends southwards to the beach. Bagnall & Petersen’s map (p38) spells it Matahi. 4 Jun 37. 
+Matuku. The actual site of Matuku, later known as Kohimarama, is on the western point of the long razor-backed ridge, on the eastern knob of which is the Matuku trig. It is situated on Mr. J. Duncan’s ‘Hiwera’ station. (Bagnall & Petersen, p.257n). The pa site is now marked on the latest edition of the map. 23-24 Feb 47; 3-6 Jan, 6-12 Dec 48; 23-27 Nov 49; 18-25 Oct 51; 19-23 Feb 52. 
 Maukopakopa. Kaukopakopa, southern Kaipara Harbour. 8-9 Feb 44. 
-Maunga Nui; Maunganui. Mt Maunganui, at the entrance to Tauranga Harbour. 6, 12 Jan 38. 
-Maunga nui, “a sandy island.” Te Wakatehaua Island, The Bluff, Ninety Mile Beach. 30 Mar 39. 
+Maunga Nui (Maunganui). Mt Maunganui, at the entrance to Tauranga Harbour. 6, 12 Jan 38. 
+Maunga nui, a sandy island. Te Wakatehaua Island, The Bluff, Ninety Mile Beach. 30 Mar 39. 
 Maunga Poẁatu. Maungapohatu, a prominent ridge on the western side of the Huiarau Range, overlooking the Ruatahuna valley. 11 Jan 44. 
-*Maungarei. Not located and not mentioned by Buchanan. It is noted by Colenso in the entry for October 16, 1851, as having been crossed the previous day on the march over steep fern-covered hills between leaving the Ngaruroro River and reaching the Kuripapango ford. The Clematis mentioned in the Journal entry is possibly “4251 Clematis …” of the list of 31 January 53. 15 Oct 51. 
+*Maungarei. Not located and not mentioned by Buchanan. It is noted by Colenso in the entry for October 16, 1851, as having been crossed the previous day on the march over steep fern-covered hills between leaving the Ngaruroro River and reaching the Kuripapango ford. The Clematis mentioned in the Journal entry is possibly 4251 Clematis … of the list of 31 January 53. 15 Oct 51. 
 Maunga Tapu. Now an eastern suburb of Tauranga. 7 Jun 38; 15-18 Jan 42; (Bagnall & Petersen p.125). 
 Maungatautiri, An elevated district situated nearly midway between the east and west coasts. The mountain lying to the west of Arapuni on the Waikato River. 
 Maunga Turoto. A village within easy riding distance of the Waimate Mission Station. Not located but not to be confused with modern Maungaturoto which is much further south. 5 Feb 37. 
-Maunu, “a deserted village near Te Waiiti, Wangarei.”A place called Maunu is marked on Highway 14 west of Whangarei. 22 Feb 36. 
-Mawe, “Morning, rode to Mawe” from Waimate. “Heke’s pa Puketutu near Lake Omapere was sometimes referred to as Te Mawhe.” (Porter p.344n quoting Cowan). 12 Aug 38. 
-Mimiha. Bagnall & Petersen (p. 246) place the village of Te Mimiha on the bank of the Mohaka River, i.e. close to the present bridge on the Taupo-Napier highway. 11-12 Feb 47. 
+Maunu, a deserted village near Te Waiiti, Wangarei.A place called Maunu is marked on Highway 14 west of Whangarei. 22 Feb 36. 
+Mawe, Morning, rode to Mawe from Waimate. Heke’s pa Puketutu near Lake Omapere was sometimes referred to as Te Mawhe. (Porter p.344n quoting Cowan). 12 Aug 38. 
+Mimiha. Bagnall & Petersen (p. 246) place the village of Te Mimiha on the bank of the Mohaka River,  (close to the present bridge on the Taupo-Napier highway). 11-12 Feb 47. 
 Mimiẁangota. Mimiwhangata is on a prominent peninsula forming the southern headland of Whangaruru Bay. 8 Oct 41. 
 Moäwango River; Moeawango. The Moawhango River rises on the western side of the Kaimanawa Mountains and flows south to join the Rangitikei southeast of Taihape. 22 Feb 47; 6 Dec 48. 
 *Moeangiangi River,(Hawke’s Bay) 10 miles inland from the sea. Moeangiangi Stream reaches the coast 25 miles north by road from Napier. 13-14 Dec 43; 25-26 Jul 45; 11-12 Nov 51; 28-30 Jan 52. 
@@ -237,35 +232,34 @@ Mokoia Island, Lake Rotorua. A visit was made to the island to examine a tree, r
 Mokorau. Mokarau Stream is on the shore of Ahipara Bay at the southern end of Ninety Mile Beach. 25 Mar 39. 
 Motukaroro. Close to Mawhai Point, the southern headland of Tokomaru Bay. 4 Dec 41. 
 *Motukino. Motukino is just south of Opepe on the Taupo-Napier highway. 4 Dec 49. 
-Te Motu o Taraia, “a potatoe plantation.”Bagnall & Petersen (p. 206) show this at the present site of Wanstead, inland from Pakowhai on the coast of southern Hawke’s Bay province. 
-Motuowai; Motu-o-wae, “…a small wood on the bank of the Waipaoa (Waipawa River), and on the SW. edge of Te Ruataniẁa plain.”Not located. 11-12 Feb 45; 29 Dec 47; 19-20? Nov 49; 27 Feb 52. 
-Moturoa. Moturoa was close to the site of the old military post beyond the Waipunga crossing (Bagnall & Petersen p.257n), i.e. on the Taupo-Napier Road. 15 Feb 47. 
-Motutere. On the eastern shore of Lake Taupo between Jellicoe Point and Motutere Point. 
-17 Feb 47; 3-4 Dec 49. 
-Mount Camel, Northern extremity of N. Island Above Perpendicular Point on the northern entrance to Houhora Harbour, Northland. Now known as Houhora No. 2, but known to Colenso by the alternative name of Maunga Taniwa. 
+Te Motu o Taraia, a potatoe plantation.Bagnall & Petersen (p. 206) show this at the present site of Wanstead, inland from Pakowhai on the coast of southern Hawke’s Bay province. 
+Motuowai; Motu-o-wae, …a small wood on the bank of the Waipaoa (Waipawa River), and on the SW. edge of Te Ruataniẁa plain.Not located. 11-12 Feb 45; 29 Dec 47; 19-20? Nov 49; 27 Feb 52. 
+Moturoa. Moturoa was close to the site of the old military post beyond the Waipunga crossing (Bagnall & Petersen p.257n), (on the Taupo-Napier Road). 15 Feb 47. 
+Motutere. On the eastern shore of Lake Taupo between Jellicoe Point and Motutere Point. 17 Feb 47; 3-4 Dec 49. 
+Mount Camel, Northern extremity of N. Island Above Perpendicular Point on the northern entrance to Houhora Harbour, Northland. Now known as Houhora No. 2, but known to Colenso by the alternative name of Maunga Taniwa..
 *Mowae. A village, now lost, in the vicinity of the Waimate Mission Station. 
 *Mukamukanui. Bagnall & Petersen (p. 218) locate Mukamukanui at the mouth of Mukamuka Stream on the western side of Palliser Bay. 6-7 Mar 46; 19 & 28-29 Apr 47; 19 May 48; 3-4 Apr 49. 
 Murimotu. Not located but situated some 20 miles west from Matuku (Bagnall & Petersen p.287). 27 Nov 49. 
 {N}
-Napier Napier was not formally laid out until 1856 so collections labelled as from Napier post-date that year. 
+Napier, Napier was not formally laid out until 1856 so collections labelled as from Napier post-date that year. 
 *Te Ngaaue Village, Ahuriri. Te Ngaue, the village of the Chief, Te Hapuku, was on the Ngaruroro River beyond Pakowhai. (Bagnall & Petersen, p.237). 
 *Ngaawapurua. Ngawapurua is located on the north bank of the Manawatu River immediately to the east of the junction with the Mangatainoka. Mar-1 Apr, 26-28 Sep 46; 1-3 Apr, 18-19 Nov 47; 4-5 Apr, 23 Nov 48; 16-17 Mar 49; 5-6 Apr 50; 17-21 May 51; 22-23 Mar 52. 
 Te Ngae Mission Station. On the eastern side of Lake Rotorua. 7-13 Jan 42. 
 Ngaere. Te Ngaere, opposite the Cavalli Islands, Northland. 10 Apr 39. 
-“Te Ngaere”, Heretaunga. Not located. Mentioned in the list of 31 January 1853. 
+Te Ngaere, Heretaunga. Not located. Mentioned in the list of 31 January 1853. 
 Ngamahanga. Arrowsmith’s 1850 map and Bagnall & Petersen (p. 66) show Ngamahanga on the west bank of the Whakatane River, not very far below the confluence with the Waikare Stream. Best’s map shows it on the east bank. 16 Jan 44. 
-Ngamoerangi. “… the important coastal pa … long since swept away by the sea” (Guthrie Smith, Tutira, 1921, p.64). Colenso indicates Ngamoerangi as being an hour’s walk from Te Kapemaihi and a short distance from Tangoio. This would suggest that the village was in the vicinity of Whirinaki Bluff, possibly on the Pakuratahi Stream. 18-20 Jan 45. 
-*Ngapihao, “A romantic and craggy point of land … about 2 miles from Ẁaraurangi.”
+Ngamoerangi. … the important coastal pa … long since swept away by the sea (Guthrie Smith, Tutira, 1921, p.64). Colenso indicates Ngamoerangi as being an hour’s walk from Te Kapemaihi and a short distance from Tangoio. This would suggest that the village was in the vicinity of Whirinaki Bluff, possibly on the Pakuratahi Stream. 18-20 Jan 45. 
+*Ngapihao, A romantic and craggy point of land … about 2 miles from Ẁaraurangi.
 Ngapihau. Not definitely located. 12 Apr 51. 
 Ngaromaki The Bluff, on Ninety Mile Beach. 30 Mar, 1 Apr 39. 
 Ngaroto. Ngaroro, summit of Ruahine. A name given by Colenso and his party to a favourite camping site on a western spur of the Ruahine Range below Te Atuaomahuru (Bagnall & Petersen, p.271n). 8-10 Jan, 13-14 Dec 48; 21-22 Nov 49. 
-Ngaruai, “2½ miles from Waikino (Bay of Islands).” Not further located. 16, 23 Aug, 20 Sep 40. 
+Ngaruai, 2½ miles from Waikino (Bay of Islands). Not further located. 16, 23 Aug, 20 Sep 40. 
 Ngaruawahie. Ngaruawahia, at the junction of the Waikato and Waipa Rivers. 27 Jan 42 (without landing); 30 Jan 44. 
 Ngaruroro River. Rises in the Kaimanawa Mountains and in flowing south, skirts to the west of the Kaweka Range, crosses the Takapau Plains to pass between Napier and Hastings, discharging into Hawke Bay at Clive. 16 Sep 47; 13 & 16 Oct 51; 16 Feb 52. 
 *Ngatahorahora stream, Forest beyond Te Hawera. Not located. The name occurs in the list of September 1847. 
 Te Ngau a te Hanehane; Te Ngautehangehange. Not located unless it be the Waiotenoanga Stream, a tributary of the Waiomio. 26-27 Feb 36; 13-14 Feb 44. 
-Ngauwaka. Colenso places this “about a mile” NNE from Toreatai, i.e. west of Maungapohatu. 12 Jan 44. 
-Ngawakatatara, Ngaẁakatatara. “Ngawakatatara was five miles downstream from Patangata, on a terrace on the west bank of the Tukituki” (Bagnall & Petersen, p.219n). 24 Apr, 20 Oct 45; 28 Jan, 8-9 Apr, 30 Jun-1 Jul 46; 24 Mar, 22 & 27 Sep, 16 Dec 48; 9 Mar, 15-16 May, 15-16 Nov 49; 4, 6 Feb, 15-16 Apr, 11-12 & 16-17 Jul, 16 Nov 50; 27 May, 11-12 Aug, 31 Oct 51; 17 Jan, 20-21 Jul, 23 Aug, 20-22 Sep 52. 
+Ngauwaka. Colenso places this about a mile NNE from Toreatai, (west of Maungapohatu). 12 Jan 44. 
+Ngawakatatara, Ngaẁakatatara. Ngawakatatara was five miles downstream from Patangata, on a terrace on the west bank of the Tukituki (Bagnall & Petersen, p.219n). 24 Apr, 20 Oct 45; 28 Jan, 8-9 Apr, 30 Jun-1 Jul 46; 24 Mar, 22 & 27 Sep, 16 Dec 48; 9 Mar, 15-16 May, 15-16 Nov 49; 4, 6 Feb, 15-16 Apr, 11-12 & 16-17 Jul, 16 Nov 50; 27 May, 11-12 Aug, 31 Oct 51; 17 Jan, 20-21 Jul, 23 Aug, 20-22 Sep 52. 
 *Ngunguru. On the coast north of Whangarei Harbour. 18-19 Dec 39; 20 Jul, 22 Sep, 5 Oct 41; 17-18 Feb 42. 
 Nihonui, Bay of Islands. Not located. 
 Northwood’s Sheep Station. See Te Ahiaruhe. 
@@ -277,89 +271,88 @@ Ohawini. Whangaruru South. Ohawini Bay is at the western head of Whangaruru Harb
 *Ohinemutu. On the western shore of Lake Rotorua. 10 Jan 42. 
 Ohineriu. On the tussock flats between the head of the Rangitaiki and Taharua Rivers, but not now marked. 15-16 Feb 47. 
 *Okahu. Presumably along the Ruamahanga River between Martinborough (Huaangarua) and Te Ahiaruhe (near Carterton) but not located. 10 Nov 47. 
-*Okokoro, “near the present Pakipaki” (Colenso, In Memoriam p.6). 4 Feb 45; 27 Feb 52. 
-*Okorewa, “The small fishing village at the mouth of the lake.” i.e. Lake Onoke on Palliser Bay (Bagnall & Petersen p.215). 24 Mar, 1-2 Apr 45. 
+*Okokoro, near the present Pakipaki (Colenso, In Memoriam p.6). 4 Feb 45; 27 Feb 52. 
+*Okorewa, The small fishing village at the mouth of the lake. (Lake Onoke on Palliser Bay) (Bagnall & Petersen p.215). 24 Mar, 1-2 Apr 45. 
 Okura. Between Pauanui and Manawarakau, mentioned only as a place where there was respite from the rocks and stones of the coast route. 7 Dec 43. 
 Omarunui. 
-*Omoekau. “About two miles inland from the mouth of the Hurupi Stream, on the Whangaimoana.” (Bagnall & Petersen p.232n). Moikau is a locality on the Turanganui River, Wairarapa, a mile beyond the end of the Whakatomotomo Road, about a mile from Bagnall & Petersen’s position. 3 Apr 45; 17 Mar 46. 
-Onaua, “Cook’s Straits.”On Ohau Bay, at the northern end of the Terawhiti Block in the southwest corner of the Wellington Peninsula. 
+*Omoekau. About two miles inland from the mouth of the Hurupi Stream, on the Whangaimoana. (Bagnall & Petersen p.232n). Moikau is a locality on the Turanganui River, Wairarapa, a mile beyond the end of the Whakatomotomo Road, about a mile from Bagnall & Petersen’s position. 3 Apr 45; 17 Mar 46. 
+Onaua, Cook’s Straits.On Ohau Bay, at the northern end of the Terawhiti Block in the southwest corner of the Wellington Peninsula. 
 Onehunga. Modern Onehunga, on the northeastern shore of Manukau Harbour. 5 Feb 44. 
 Te Onepoto, Waikare. The village on Lake Waikaremoana at the outfall of the lake. 24-29 Dec 41; 20-26 Dec 43. 
-Onepoto, “Mr Alexander’s trading station.”On the southern side of modern Bluff Hill, Napier, and originally on the shore of Ahuriri Lagoon. 
+Onepoto, Mr Alexander’s trading station.On the southern side of modern Bluff Hill, Napier, and originally on the shore of Ahuriri Lagoon. 
 Te Onepoto, East Coast. See Ouepoto. 
 Te Onepu. Arrowsmith’s 1850 map marks Onepu on the west bank of the Whirinaki about halfway between the Okahu Stream and the Rangitaiki. 4 Jan 44. 
 *Te Onetapu. The rain-shadow area to the east of the Tongariro group of volcanoes. 18 Feb 47. 
-Onewaka, “on the boldly-curved bank of the river Kopau (the upper part of the Kawakawa).” Not located. 1-2 Jun 36. 
-Opaoho, “a village about 4½ miles from the Kawakawa … on the brow of a very high hill.” Not located. 13 Oct 39; 9 Feb, 8 Mar, 10 Oct 40; 17 Jan 41. 
+Onewaka, on the boldly-curved bank of the river Kopau (the upper part of the Kawakawa). Not located. 1-2 Jun 36. 
+Opaoho, a village about 4½ miles from the Kawakawa … on the brow of a very high hill. Not located. 13 Oct 39; 9 Feb, 8 Mar, 10 Oct 40; 17 Jan 41. 
 *Oparapara, Ruahine Mountains; Parapara. Te Atuaoparapara (5450 feet alt.) is at the head of the Waipawa River on the main divide. The name appears in one form or another in the lists of July 1846 and 31 January 1853. 
 Oparua. On the Makororo River. Not located and not mentioned by Buchanan. 7-8 Feb 45. 
-Opitonui, “…between Tarawera and the edge of the Taupo plains (In Memoriam p.35).” Kopitonui Stream flows from Kaimatangi on the west of the Taupo-Napier Road two or three miles north of the old mineral baths at Tarawera. 15 Feb 47. 
-Oporae, “(a small village lately formed on the banks of the Ngaruroro River).” Not mentioned by Buchanan. 
+Opitonui, …between Tarawera and the edge of the Taupo plains (In Memoriam p.35). Kopitonui Stream flows from Kaimatangi on the west of the Taupo-Napier Road two or three miles north of the old mineral baths at Tarawera. 15 Feb 47. 
+Oporae, (a small village lately formed on the banks of the Ngaruroro River). Not mentioned by Buchanan. 
 Oputao. Oputao is a short distance southwest of Ruatahuna, Urewera. 3-4 Jan 42; 29-30 Dec 43; 6-8 Jan 44. 
 Orarotauira, A small village on the Waiohingaanga River. Not located. 22 Apr, 1 May 46; 9-10 Feb 47. 
-Orauta, “about six miles distant” (from Kawakawa). The present Orauta Mission School is on the south side of the Otiria Stream at Tuhipa. 10 Nov 39; 5 Jan 40. 
-*Oroi. “Oroi, on a broad grassy flat sheltered by a still extensive karaka grove, was about two miles south of the present Tora station.” (Bagnall & Petersen, p.219n). The Oroi Stream enters the sea about two miles north of Te Kaukau Point on the Wairarapa coast. 10 Mar, 21-22 Nov 45; 27-28 Feb, 1-2 Mar, 10 Sep 46; 5-6 May, 20-21 Oct 47; 25-26 Apr, 7-8 Nov 48; 15-17 Apr 51; 7-8 Apr 52. 
-*Orona. Best 1897 (p63n) gives “… Orona, or Hamaria – its modern name.” The topographic maps give Hamuria as an alternative name for Halletts Bay on the eastern shore of Lake Taupo just south of the Hinemaiaia Stream which was Colenso’s access route to the lake. 16-17 Feb 47. 
+Orauta, about six miles distant (from Kawakawa). The present Orauta Mission School is on the south side of the Otiria Stream at Tuhipa. 10 Nov 39; 5 Jan 40. 
+*Oroi. Oroi, on a broad grassy flat sheltered by a still extensive karaka grove, was about two miles south of the present Tora station. (Bagnall & Petersen, p.219n). The Oroi Stream enters the sea about two miles north of Te Kaukau Point on the Wairarapa coast. 10 Mar, 21-22 Nov 45; 27-28 Feb, 1-2 Mar, 10 Sep 46; 5-6 May, 20-21 Oct 47; 25-26 Apr, 7-8 Nov 48; 15-17 Apr 51; 7-8 Apr 52. 
+*Orona. Best 1897 (p63n) gives … Orona, or Hamaria – its modern name. The topographic maps give Hamuria as an alternative name for Halletts Bay on the eastern shore of Lake Taupo just south of the Hinemaiaia Stream which was Colenso’s access route to the lake. 16-17 Feb 47. 
 Orongorongo. At the mouth of the Orongorongo River, west of Palliser Bay. 24-25 Mar, 10-11 Nov 45; 20 Apr 47. 
-Oropa, “distant about 4 miles” (from Kawakawa). Not located. 17 Feb, 10 Nov 39; 5 Jan 40. 
+Oropa, distant about 4 miles (from Kawakawa). Not located. 17 Feb, 10 Nov 39; 5 Jan 40. 
 Oropauanui. See Aropauanui. 
 *Oroua River. A tributary of the Manawatu on the western side of the Ruahine Range. 30 Nov-2 Dec 48. 
 Oruhi. Oruhi was at the mouth of the Whareama River, south of Castle Point. 14 Mar 45. 
-Oruneke, “part of Oruru.” The Oruru River flows north into Doubtless Bay. Oruneke has not been located. 8-9 Apr 39. 
+Oruneke, part of Oruru. The Oruru River flows north into Doubtless Bay. Oruneke has not been located. 8-9 Apr 39. 
 *Otahuhu. The Mission Station of W. T. Fairburn, Colenso’s father-in-law. The station was close to the shore of the modern suburb of Auckland. 7-8 Feb 38; 2-4 Feb 41; Jan 43; 2-5 Feb 44. 
-*Otaika, “A village in Wangarei Bay.” About four miles south of Whangarei. See also Taika. 
-Otakahia. “Three hours’ march north from Matapouri,” which suggests Sandy Bay on the south side of Whananaki Inlet. 19-20 Dec 39. 
+*Otaika, A village in Wangarei Bay. About four miles south of Whangarei. See also Taika. 
+Otakahia. Three hours’ march north from Matapouri, which suggests Sandy Bay on the south side of Whananaki Inlet. 19-20 Dec 39. 
 Otamarakau. On the Bay of Plenty coast at the eastern end of Pukehina Beach. 23 Jan 44. 
 Otamarora. On the Bay of Plenty Coast. Arrowsmith’s 1850 map indicates it west of the [old] mouth of the Rangitaiki River, very close to modern Matata. Drury [1854, p.61. 6 Jun 1854] places it 2½ miles west of the junction of the Matata and Orini rivers and a mile from the mouth. 23 Jan 44. 
 Otamatea inlet, Kaipara Harbour. The Otamatea River enters the Harbour almost directly opposite the harbour entrance. 12-13 Feb 42. 
 Otanenuirangi; Tanenuiarangi. Bagnell and Petersen (p. 23) show Otanenuiarangi on the southern bank of the Ngaruroro River immediately north of Te Pakiaka Bush. 
-*Otara. “Otara was situated at a spot a mile or so from the present township of Ohingaiti. A ford existed opposite the village and was in use until badly washed out by floods in the ’nineties. The present Otara road bridge on the Ohingaiti-Rangiwahia road is slightly upstream from the old village and ford.” (Bagnall & Petersen, p.292n). 
+*Otara. Otara was situated at a spot a mile or so from the present township of Ohingaiti. A ford existed opposite the village and was in use until badly washed out by floods in the ’nineties. The present Otara road bridge on the Ohingaiti-Rangiwahia road is slightly upstream from the old village and ford. (Bagnall & Petersen, p.292n). 
 *Otaraia. Wairarapa valley; Oteraia. Otaraia is on the bank of the Ruamahanga River at its closest approach to the Martinborough-Lake Ferry Road. 4 Apr, 6 Nov 45; 18 Mar, 16-17 Sep 46;  14-15 Apr 47; 25-26 May, 14-15 Nov 48; 29 Mar 49; 22-23 Apr 51; 31 Mar-1Apr 52. 
 Otawao, Waikato. The Mission Station on the site of modern Te Awamutu. 24-26 Jan 42. 
-*Otawao, Manawatu. Bagnall & Petersen (p. 206) show Otawhao on the west bank of the Manawatu River south of Dannevirke. They state that “The village was south of Otawhao-Manawatu junction between Kumeroa and Dannervirke (p. 233n). Otawhao is a locality on the south side of the Manawatu east of Kumeroa. 1-2 Apr, 28-29 Sep 46; 19-22 Nov 47. 
-*Oterango, “Cook’s Straits.” At the southern end of the Terawhiti block in the southwest corner of the Wellington peninsula. 8 May 48. 
-Otihere. “Otiere … pa, on Ihooterei Island” (Buchanan p.162), i.e. on the old Ahuriri Lagoon. 19 Jun 49. 
+*Otawao, Manawatu. Bagnall & Petersen (p. 206) show Otawhao on the west bank of the Manawatu River south of Dannevirke. They state that The village was south of Otawhao-Manawatu junction between Kumeroa and Dannervirke (p. 233n). Otawhao is a locality on the south side of the Manawatu east of Kumeroa. 1-2 Apr, 28-29 Sep 46; 19-22 Nov 47. 
+*Oterango, Cook’s Straits. At the southern end of the Terawhiti block in the southwest corner of the Wellington peninsula. 8 May 48. 
+Otihere. Otiere … pa, on Ihooterei Island (Buchanan p.162), (on the old Ahuriri Lagoon). 19 Jun 49. 
 Otiki. Colenso gives the Māori name for East Cape as Otiki; it is also the name of the trig station at the Cape. 17 Jan 38; 25 Nov 41. 
-Otuihu. “Otuihu was situated on the upper harbour on a bluff on the south headland of Waikare Inlet” (Bay of Islands) (Bagnall & Petersen, p.64n). Colenso records numerous visits at roughly monthly intervals from February 1835 to October 1839. 
+Otuihu. Otuihu was situated on the upper harbour on a bluff on the south headland of Waikare Inlet (Bay of Islands) (Bagnall & Petersen, p.64n). Colenso records numerous visits at roughly monthly intervals from February 1835 to October 1839. 
 *Otukopeka. Arrowsmith’s 1850 map shows a hill so named west of Ahikereru, Urewera. It is marked by a modern trig. 1 Jan 44. 
-Otumoetai. Now a suburb of Tauranga. 7-10 Jun 38; Jan 42 (15-18 in Bagnall & Petersen, p.125)
-*Oturereawa River; Otureawa River Otuareiawa Stream joins the Moawhango River just north of the latter’s confluence with the Rangitikei. This is just below the site of Matuku pa. 28 Oct 51. 
-Otuẁareana, “a small wood.” About two miles south of Otaraia, on the Ruamahanga River, Wairarapa. 3-4 Apr 45. 
+Otumoetai. Now a suburb of Tauranga. 7-10 Jun 38; Jan 42 (15-18 in Bagnall & Petersen, p.125).
+*Oturereawa River. Otureawa River Otuareiawa Stream joins the Moawhango River just north of the latter’s confluence with the Rangitikei. This is just below the site of Matuku pa. 28 Oct 51. 
+Otuẁareana, a small wood. About two miles south of Otaraia, on the Ruamahanga River, Wairarapa. 3-4 Apr 45. 
 Oue. Colenso gives this as 1½ hours, about 5 miles, from Kawakawa, but it has not been further located. 18 Nov 38. 
-*Ouepoto, “A sandy flat … near Cape Turnagain.” Arrowsmith’s 1850 map shows “Uepoto” just north of Black Head. This corresponds with modern Aramoana, and should not be confused with Te Onepoto south of Waimarama. Colenso’s spelling is consistent and is supported by Arrowsmith’s version. 6 Dec 43; 12-13 Feb 46; 27-28 Oct 48; 5-6 Mar, 26-27 Nov 50; 29 Apr-1 May 52. 
+*Ouepoto, A sandy flat … near Cape Turnagain. Arrowsmith’s 1850 map shows Uepoto just north of Black Head. This corresponds with modern Aramoana, and should not be confused with Te Onepoto south of Waimarama. Colenso’s spelling is consistent and is supported by Arrowsmith’s version. 6 Dec 43; 12-13 Feb 46; 27-28 Oct 48; 5-6 Mar, 26-27 Nov 50; 29 Apr-1 May 52. 
 *Owae. Bagnall & Petersen (p. 38) place this on Helena Bay, Whangaruru Bay, presumably near the mouth of the Owai Stream which flows into the southwest corner of Helena Bay. 13-17 Feb 36; 21-24 Jun, 26-30 Sep, 21-23 Dec 39; 7-8 Jan, 14-16 Aug, 20-22 Sep, 8-11 Oct 41; 18-21 Feb 42. 
 *Owahanga River. North of the Mataikona River and apparently not to be confused with the settlement on the north side of the Mataikona River mouth. 28 Nov 45; 28 Aug 46; 6 Jun 48; 1-2 May 49. 
 Oẁakau. On the Tutaekuri River near the point where the ascent of Kuripapango (Te Kohurau) began, but not located. 14 Feb 52. 
-Oẁiorangi. Owiorangi appears on Arrowsmith’s 1850 map as on the west bank of the Waikare River near “Warau”, Urewera. This indicates a position near Otahuao. 12 Jan 44. 
+Oẁiorangi. Owiorangi appears on Arrowsmith’s 1850 map as on the west bank of the Waikare River near Warau, Urewera. This indicates a position near Otahuao. 12 Jan 44. 
 
-Paharakeke (a small wood). Paharakeke Stream drains into Rangatea Lagoon near the southern end of Lake Wairarapa. 6 Nov 45; 18 Mar 46. 
-*Paharakeke Wood, near Patea. This locality does not appear in the Journal but in the list of 31 January 1853, and might possibly be a confusion with the Wairarapa wood of the same name. The specimen, 4257 Hymenophyllum, is not represented at WELT so no decision based on phytogeographic considerations can be made. 
+Paharakeke, (a small wood). Paharakeke Stream drains into Rangatea Lagoon near the southern end of Lake Wairarapa. 6 Nov 45; 18 Mar 46. 
+*Paharakeke Wood, near Patea. This locality does not appear in the Journal but in the list of 31 January 1853, and might possibly be a confusion with the Wairarapa wood of the same name. The specimen, 4257 Hymenophyllum, is not represented at WELT so no decision based on phytogeographic considerations can be made.. 
 *Pahawa. The Pahaoa River on the Wairarapa coast. 18 Mar, 22-24 Nov 45; 25-27 Feb, 8-9 Sep 46; 6-10 May, 16-19 Oct 47; 20-24 Apr, 4-7 Nov 48; 24-26 Apr 49; 16-19 Mar 50; 12-14 Apr 51; 10-14 Apr 52. 
 *Pahiatua, near the R. Manawatu. Modern Pahiatua on the Mangatainoka River south of its junction with the Manawatu. This locality does not occur at all in the Journal, but appears fairly commonly in the lists after 1848. 
 Pahitaua. Arrowsmith’s 1850 map shows Pahitaua as close to the east bank of the Whakatane. Colenso travelled ENE to Pahitaua before turning southeast to Te Rangaataneiti, which would indicate Pahitaua as being in the vicinity of the hill now known as Rangiahua. 10 Jan 44. 
 *Paihia, Bay of Islands. Colenso was in residence here from 31 December 1834 until 12 June 1843. 
-*Pakarae. “… at the northern end of Whangara Bay, at the mouth of the Pakarae stream.” (Bagnall & Petersen, p.136n) i.e. about four miles south of Gable End Foreland. 8-9 Dec 41; 30 Oct 43. 
-Pakaraka. On the main highway between Kawakawa and Ohaeawai. Colenso described it as “(Mr Edward Williams’) farm about 13 miles inland” from Paihia. 15 Apr 39. 
+*Pakarae. … at the northern end of Whangara Bay, at the mouth of the Pakarae stream. (Bagnall & Petersen, p.136n) (about four miles south of Gable End Foreland). 8-9 Dec 41; 30 Oct 43. 
+Pakaraka. On the main highway between Kawakawa and Ohaeawai. Colenso described it as (Mr Edward Williams’) farm about 13 miles inland from Paihia. 15 Apr 39. 
 Pakaraka, 4 miles from Pihoi in the Ẁangarei district. In 1841, Pakaraka was reached from Pataua in half a day. From Pakaraka the Bay was crossed to Pohue and recrossed to Tamatarau. This suggests that Pakaraka was at the head of Whangarei Harbour, on the present site of Whangarei. 10 Dec 39; 27-28 Sep 41. 
 Pakarau. Pakarau was reached in 2½ hours’ travelling northwest and west from Tapiri. Assuming Tapiri and Matamata to be the same or contiguous places, Pakarau would have been in the vicinity of modern Morrinsville. 
-Pakeaka, Te, Forest, nr. Mission Station, Hawkes Bay. 
-Shown by Bagnall and Petersen (p. 237) as being some two miles west of the mouth of the Tukituki River. 
+Pakeaka, Te, Forest, nr. Mission Station, Hawkes Bay. Shown by Bagnall and Petersen (p. 237) as being some two miles west of the mouth of the Tukituki River. 
 *Te Pakiaka, near Station, Ahuriri. Bagnall & Petersen (p. 237) show Pakiaka Bush on the approximate site of Mangateretere south of Whakatu. The name does not appear in the Journal, but first appears in the list of 22 December 1846. 
-*Pakoẁai, Te Pakowai village – i.e. near “the 2 teeth”. Bagnall & Petersen (p. 206) show Pakowhai at Black Head (Parimahu). Colenso, however, in an undated list, described it as “near ‘the 2 Teeth’”. Arrowsmith’s 1850 map shows the “2 teeth” as about halfway between Porangahau and Cape Turnagain. Arrowsmith would appear to have confused the “2 Teeth” with Cook’s Tooth. 13 Feb, 22 Aug 46; 24-25 May, 5-6 Oct 47; 12-13 Jun, 28 Oct 48. 
+*Pakoẁai, Te Pakowai village –  near the 2 teeth. Bagnall & Petersen (p. 206) show Pakowhai at Black Head (Parimahu). Colenso, however, in an undated list, described it as near ‘the 2 Teeth’. Arrowsmith’s 1850 map shows the 2 teeth as about halfway between Porangahau and Cape Turnagain. Arrowsmith would appear to have confused the 2 Teeth with Cook’s Tooth. 13 Feb, 22 Aug 46; 24-25 May, 5-6 Oct 47; 12-13 Jun, 28 Oct 48. 
 Pakuku. Bagnall & Petersen (p. 217n) suggest that this is the present Papuku Stream, south of Cape Turnagain. 10-11 Mar 45; 16 Apr, 24-25 Oct, 29 Nov 45; 17-19 Feb, 26-28 Aug 46; 19-20 May, 9-11 Oct 47; 30-31 Oct 48. 
 *Pakura, Dense forests near Ruatahuna. Not located. 
 *Palliser Bay. The deep, wide bay at the southern end of the North Island. 19-25 Mar, 1-3 Apr, 6-11, 18-21 Nov 45; 2-7, 13-17 Mar, 11-16 Sep 46; 15-20 & 28 Apr-5 May, 21-27 Oct 47; 26 Apr-2 May, 8-13 Nov 48; 29 Mar-3 Apr 49; 17-19 Apr 51. 
-*Pamateao. Described by Colenso as a “desert beach” and as “a point 20 miles N. of Cape Palliser” but the name has not been found on any maps including those of Arrowsmith. 7 Apr 52. 
+*Pamateao. Described by Colenso as a desert beach and as a point 20 miles N. of Cape Palliser but the name has not been found on any maps including those of Arrowsmith. 7 Apr 52. 
 *Panekiri; Panekire. Panekiri Range on the southern shore of Waikaremoana but not mentioned in the Journal. 21-26 Dec 43. 
 Te Papa. Not located, but presumably on the northern Rangitaiki Plains. 5-7 Dec 49. 
 Te Papa. Mission Station, Tauranga. 5-12 Jan 38; 25-26 Jan 44. 
 Papakoẁatu. Arrowsmith’s 1850 map shows this on the east bank of the Whakatane, below the Waimana confluence. 20 Jan 44. 
 *Papakura plains. On the east shore of Manukau Harbour. 1-2 Feb 44. 
-Paparaumu; Paparaaumu. Bagnall & Petersen (p. 38) show this north of Owae, in the approximate position of modern Mokau on the Whangaruru Harbour. The name does not appear on modern maps. 24 Jun, 30 Sep-1 Oct, 23 Dec 39; 6-7 Jan, 16-17 Aug 41. 
+Paparaumu; Paparaaumu. Bagnall & Petersen ( p. 38) show this north of Owae, in the approximate position of modern Mokau on the Whangaruru Harbour. The name does not appear on modern maps. 24 Jun, 30 Sep-1 Oct, 23 Dec 39; 6-7 Jan, 16-17 Aug 41. 
 Parae. Appears on a few wrappings. Not a locality but a Māori word meaning undulating or level country. 
-*Parakaraka. May be modern Kiripaka, on the Ngunguru River. This seems to be the “Pakarohu” of Bagnall & Petersen (p. 101) but Colenso records no botanical finds. 5 Oct 41. 
+*Parakaraka. May be modern Kiripaka, on the Ngunguru River. This seems to be the Pakarohu of Bagnall & Petersen ( p. 101) but Colenso records no botanical finds. 5 Oct 41. 
 Parangahau, Cook’s Straits. Probably a slip for the following.  
-*Parangarahu. Parangarahu “was … on the flat before Baring Head, to the east of the Paiaka Stream.” (Bagnall & Petersen, p.219n). 
+*Parangarahu. Parangarahu was … on the flat before Baring Head, to the east of the Paiaka Stream. (Bagnall & Petersen, p.219n). 
 Parapara, The topmost range of the Ruahine mountains. See Oparapara. 
 Paremata Hill,A high, conical hill between Whangaruru & Waikare. Paremata, 1280 feet alt., is inland from Helena Bay, Whangaruru Harbour. 16 Apr 35. 
 Paratetaitonga. The northern peak of the Ruapehu summit crater. Colenso appears to use the name interchangeably with Ruapehu. 28 Nov 49. 
@@ -368,18 +361,18 @@ Parewarewa, On the west bank of the Whakatane River, 1½ miles downstream from T
 Parikarangaranga, On the Turanganui River, Wairarapa. Pakarangaranga is a trig point to the north of the river about two miles from the junction of the Pirinoa and Whakatomotomo Roads. 3 Apr 45; 29-30 Mar 49. 
 *Parimahu. Black Head, on the East Coast south of Cape Kidnappers. 6 Dec 43; 6-7 Mar, 1-2 Dec 45; 6 Mar 50; 27-28 Mar 51; 28 Apr 52. 
 Parinuiotera. Gable End Foreland, north of Poverty Bay. 25 Jan 38; 8 Dec 41. 
-Paripokai, “Nr. River Wangaehu, Taupo.” Not located. 
+Paripokai, Nr. River Wangaehu, Taupo. Not located. 
 Paroa Bay; Paro Bay. On the south shore of the main channel of the Bay of Islands, and east of Russell. 30 May, 3 Jul 36. 
 *Parua. On Parua Bay, a deep bay on the north shore of Whangarei Harbour. 2-4 Oct 41. 
 *Patangata. On the bank of the Tukituki River, east of Waipawa. 23-24 Apr, 20 Sep, 20 Oct 45; 28-29 Jan, 8 Apr, 24-25, 30 Jun, 5-6 Oct 46; 9, 13-14 Jan, 2-3, 25 Mar, 10-11 Sep, 27-29 Nov 47; 24 Mar, 22-23, 26-27 Sep, 16-18 Dec 48; 9 Mar, 16-21 May, 16-17 Oct 49; 4-6 Feb, 13-15 Apr, 15-16 Jul, 16-19 Nov 50; 9-11 Aug, 31 Oct 51; 17-19 Jan, 21 Sep 52. 
-*Pataua, “Pataua Creek, near Wangarei, E. Coast.” At the southern end of Ngunguru Bay. 27 Sep 41. 
-*Patea, Western base of Ruahine range. The statement in In Memoriam (p. 72) that two visits were made in 1852, the second in May, is not borne out by the Journal. The events described occurred on the February 1852 visit. 23-24 Feb 47; 1-3, 6-7 Jan, 6-13 Dec 48; 22-27 Nov 49; 18-27 Oct 51; 19-24 Feb 52. 
+*Pataua, Pataua Creek, near Wangarei, E. Coast. At the southern end of Ngunguru Bay. 27 Sep 41. 
+*Patea, Western base of Ruahine range. The statement in In Memoriam ( p. 72) that two visits were made in 1852, the second in May, is not borne out by the Journal. The events described occurred on the February 1852 visit. 23-24 Feb 47; 1-3, 6-7 Jan, 6-13 Dec 48; 22-27 Nov 49; 18-27 Oct 51; 19-24 Feb 52. 
 *Pauanui;?Black Head. Paoanui Point is north of Tuingara and thus considerably north of Black Head or Parimahu. Colenso appears to have mistakenly applied Cook’s name in the earlier instances. 7 Dec 43; 6 Mar 45; 13-14 Jun 48. 
 Penaruku. See Punaruku. 
-Pepepe. B. Y. Ashwell’s Mission Station on the Waikato River. Colenso took an hour to travel by canoe from Ngaruawahia downstream to Pepepe, and Arrowsmith’s 1850 map shows it on the west bank well below the Waipa junction. Cowan (1922, illustration p.24-25) shows Ashwell’s station, Kaitotehe, “opposite Taupiri”. Pascoe (Exploration in N.Z. 1971, p.20) also refers to “Pepepe Mission Station … Near Taupiri …”. 30-31 Jan 44. 
-*Petane; Petani. A few miles north of Ahuriri at the northern end of the old lagoon and at the mouth of the Esk River. The name, a rendering of Bethany, is a replacement for Te Kapemaihi. The change could possibly have taken place at Christmas 1848. The Native Teacher, Paul Toki, is named for both place names. Lambert (p. 312) has another name, Kaiarero, as the old name for Petane, but does not mention Te Kapemaihi. Buchanan (p. 168) cites yet another name, Oharua. 30-31 Jan, 14-15, 18-19 Jun, 12-13 Dec 49; 11-12, 14-15 Jan, 9-10, 15-20 May, 17-18 Jun, 2-3 Oct, 20-21, 23-24 Dec 50; 1-3, 5-10 Mar, 2-4 Jun, 27-29 Sep 51; 13 Nov, 16-17 Dec 51; 10-13, 30-31 Jan, 5-7 Jun, 1-3 Jul, 11-12, 14, 26-27 Aug 52. 
+Pepepe. B. Y. Ashwell’s Mission Station on the Waikato River. Colenso took an hour to travel by canoe from Ngaruawahia downstream to Pepepe, and Arrowsmith’s 1850 map shows it on the west bank well below the Waipa junction. Cowan (1922, illustration p.24-25) shows Ashwell’s station, Kaitotehe, opposite Taupiri. Pascoe (Exploration in N.Z. 1971, p.20) also refers to Pepepe Mission Station … Near Taupiri …. 30-31 Jan 44. 
+*Petane; Petani. A few miles north of Ahuriri at the northern end of the old lagoon and at the mouth of the Esk River. The name, a rendering of Bethany, is a replacement for Te Kapemaihi. The change could possibly have taken place at Christmas 1848. The Native Teacher, Paul Toki, is named for both place names. Lambert ( p. 312) has another name, Kaiarero, as the old name for Petane, but does not mention Te Kapemaihi. Buchanan ( p. 168) cites yet another name, Oharua. 30-31 Jan, 14-15, 18-19 Jun, 12-13 Dec 49; 11-12, 14-15 Jan, 9-10, 15-20 May, 17-18 Jun, 2-3 Oct, 20-21, 23-24 Dec 50; 1-3, 5-10 Mar, 2-4 Jun, 27-29 Sep 51; 13 Nov, 16-17 Dec 51; 10-13, 30-31 Jan, 5-7 Jun, 1-3 Jul, 11-12, 14, 26-27 Aug 52. 
 Piarere Ravine. On Lake Karapiro, Waikato River, where the river turns abruptly from north to west. 21 Jan 42. 
-Pihoe; Pihoi. Bagnall & Petersen (p. 38) show this at the southwest corner of modern Whangarei. 9-11, 14-17 Dec 39; 30 Sep 41. 
+Pihoe; Pihoi. Bagnall & Petersen ( p. 38) show this at the southwest corner of modern Whangarei. 9-11, 14-17 Dec 39; 30 Sep 41. 
 Pikitanga, Ruahine Forest Pikitanga on R. Makororo. Not a locality name, but a Māori word meaning ascent, as of a mountain, in this case the Ruahines. This is an interesting instance of Colenso’s bilingualism. 
 Pipi, About a mile and quarter from Te Kape. Downstream from present-day Ruatahuna. Arrowsmith’s 1850 map shows it on the east bank of the Whakatane River. 8-9 Jan 44. 
 Pirapirau, A small village in the Tarawera district (In Memoriam, p.34). Not located. The Journal does not mention it. 12-15 Feb 47. 
@@ -387,39 +380,39 @@ Pirau, River, Tutaekuri. Not located. Buchanan (Map 3) shows a locality Pirau on
 *Te Pito. Te Pito Stream reaches the sea at Waikori Bluff, three miles south of East Cape. 25-26 Nov 41. 
 Pitokuku. Pitokuku Point is at the southern end of the sand spit which forms the south head of Whananaki Inlet. 7 Oct 41. 
 Pitoone. Modern Petone, at the northern end of Wellington Harbour. 25-26, 30-31 Mar, 11, 13-17 Nov 45; 7-9, 11-12 Mar 46; 20, 23-28 Apr, 27-28, 30-31 Oct, 1-4 Nov 47; 3 May, 13-15, 17-18 May 48; 3-4, 7-9, 14-17 Apr 49. 
-Pohatupapa. This appears to be the same as the present locality of Blackhead, north of the promontory of that name, which identification is supported by Buchanan (p. 168). 6 Dec 43; 8-9 May 49. 
+Pohatupapa. This appears to be the same as the present locality of Blackhead, north of the promontory of that name, which identification is supported by Buchanan ( p. 168). 6 Dec 43; 8-9 May 49. 
 Pohue, Ẁangarei. Not identified unless it be the modern Pohe Island, but this would seem to be on the wrong shore from Colenso’s description. 28-29 Sep 41. 
 Te Pohue, Hawke’s Bay. On Highway 5 from Napier to Taupo, 29 miles from Napier. 23 Apr 46; 29-30 Jan 49. 
 Te Poraiti. On the west shore of the Inner Harbour, Ahuriri, about opposite the entrance. 16-18 Jun 45; 23 Jun 47; 17 Oct 48; 16 Jan 50; 29 Jun 52. 
 *Porangahau. On the Porangahau River between Black Head and Cape Turnagain, about 50 miles south of Cape Kidnappers. 4-6 Dec 43; 17-21 Apr, 22-24 Oct, 29 Nov-1 Dec 45; 13-17 Feb, 22-26 Aug 46; 20-24 May, 6-7 Oct 47; 9-12 Jun, 28-30 Oct 48; 5-8 May 49; 22-26 Nov 50; 28 Mar-1 Apr 51; 24-28 Apr 52. 
 Porokanae. A little village near Haruru, presumably on the Waitangi River, Bay of Islands. 26 May 39. 
 Te Poroporo. Cape Turnagain of Cook. 10 Mar 45; See also Cape Turnagain. 
-Poroutaẁao, “8 or 9 miles” (north from Waiorongo and) “about 2 miles” (from Mataikona). Not mentioned by Colenso on other journeys along this coast. It may be the same as “Te Rerenga” of Arrowsmith’s 1850 map. 16 Nov 43. 
+Poroutaẁao, 8 or 9 miles (north from Waiorongo and) about 2 miles (from Mataikona). Not mentioned by Colenso on other journeys along this coast. It may be the same as Te Rerenga of Arrowsmith’s 1850 map. 16 Nov 43. 
 *Port Nicholson. Wellington Harbour. 25-31 Mar, 11-17 Nov 45; 7-12 Mar 46; 3-17 Apr 49. 
 Porua,A steep hill on upper reaches of Wairua River, Ẁangarei. Porua, a hill near the west bank of the Wairua, northwest from Whangarei. 25-26 Feb 36. 
-*Poukawa, Ahuriri. Poukawa Lake lies to the west of the Tukituki River, 11 miles south of Hastings. 
-Pounga, “a little deserted village” (on the Rangitikei River upstream from Otara, present Ohingaiti, but not located). 4-5 Dec 48. 
-Poureatua; Poureetua,One hour’s walk to East Cape. Not now so named, but Bagnall & Petersen (p. 66) show Poureatua on what is now Haumai Beach. 17 Jan 38; 25 Nov 41. 
+*Poukawa, Ahuriri. Poukawa Lake lies to the west of the Tukituki River, 11 miles south of Hastings.. 
+Pounga, a little deserted village (on the Rangitikei River upstream from Otara, present Ohingaiti, but not located). 4-5 Dec 48. 
+Poureatua; Poureetua,One hour’s walk to East Cape. Not now so named, but Bagnall & Petersen ( p. 66) show Poureatua on what is now Haumai Beach. 17 Jan 38; 25 Nov 41. 
 Poutu. On the eastern shore of Lake Rotoaira, the small lake south of Lake Taupo. It is presumably the same village mentioned on 18-19 Feb 47; 29 Nov-1 Dec 49. 
 Poututu. Possibly to be equated with Potua Stream, three miles east of the Waihua River in northern Hawke’s Bay. A feature, Potutu, is marked three to four miles inland. 30-31 Jul, 16 Aug 45. 
 *Poverty Bay. 26-29 Jan 38; 10-20 Dec 41; 24 Dec 44; 6-13 Aug 45. 
 Pua. On the Kawakawa River, downstream (?) from Otuihu. Presumably the modern Opua. 28 Aug 36; 27 Jan 39. 
-*Puehutai. “Puehutai was on the Manawatu, just before the loop opposite Oringi” (Bagnall & Petersen, p.233n) i.e. a few miles south of Dannevirke. 2 Apr, 29-30 Sep 46; 29 Mar-1 Apr 47; 3 Mar, 1-4 Apr, 23-27 Nov 48. 14-16 Mar 49; 6-9 Apr 50; 21-22 May 51; 18-22 Mar 52. 
+*Puehutai. Puehutai was on the Manawatu, just before the loop opposite Oringi (Bagnall & Petersen, p.233n) (a few miles south of Dannevirke). 2 Apr, 29-30 Sep 46; 29 Mar-1 Apr 47; 3 Mar, 1-4 Apr, 23-27 Nov 48 14-16 Mar 49; 6-9 Apr 50; 21-22 May 51; 18-22 Mar 52. 
 Puhangina River. The Pohangina River flows south along the western foothills of the Ruahine Range to join the Manawatu. 29 Nov 48. 
 Pukaki. Pukaki Creek reaches Manukau Harbour at the eastern end of the runway of Mangere Airport. 4 Feb 44. 
 Pukatea, Waikato River. Not located. 28 Jan 42. 
 Te Puke; Tepuke. Now a trig station and lookout point in the Waitangi (State Forest) National Reserve, Bay of Islands. 5, 12 Jul 35. 
-Pukehore. “On the coast between Tolago Bay and Gable End Foreland.” 25 Jan 38. 
-*Pukekura Hill, “Pukekura, nr. Eparaima.” To the west of the Waipukurau – Porangahau Road, a short distance north of Wanstead. 21 Apr 45. 
-Pukemaire. “Pukemaire was on the west bank of the Waiapu River, slightly north by west of the present-day Port Awanui” (Bagnall & Petersen, p.161n). 25-26 Oct 43. 
+Pukehore. On the coast between Tolago Bay and Gable End Foreland. 25 Jan 38. 
+*Pukekura Hill, Pukekura, nr. Eparaima. To the west of the Waipukurau – Porangahau Road, a short distance north of Wanstead. 21 Apr 45. 
+Pukemaire. Pukemaire was on the west bank of the Waiapu River, slightly north by west of the present-day Port Awanui (Bagnall & Petersen, p.161n). 25-26 Oct 43. 
 Pukeokui, Ẁangarei. Not located but would appear to have been southwest of Whangarei, 1½ hours from the Wairua River. This may have been in the vicinity of Waiotama on Highway 14. 22-23 Feb 36. 
 *Puke Taramea. A prominent knob on the western ridge of the Ruahine Range adjacent to the Mokai Patea Ridge. 27-28 Oct 51; 24-25 Feb 52. 
-Puketere, “A small hill …” Hukatere, about a third of the way north on Ninety Mile Beach. The spelling, Pukatere, appears on the Geological Sketch Map of the Northern District of … Auckland, 1866. 
-Puketona. Bagnall & Petersen (p. 38) show it at the junction of the Waiaruhe and Waitangi Rivers, Bay of Islands. 10 Jan 36. 
+Puketere, A small hill … Hukatere, about a third of the way north on Ninety Mile Beach. The spelling, Pukatere, appears on the Geological Sketch Map of the Northern District of … Auckland, 1866..
+Puketona. Bagnall & Petersen ( p. 38) show it at the junction of the Waiaruhe and Waitangi Rivers, Bay of Islands. 10 Jan 36. 
 Te Puku. Te Puku is a headland a short distance south of Waimarama. 8 Dec 43. 
-Tepukuotokotahu, “the next village” (after Hinukuku of the Waiomio valley). Numerous visits are mentioned between September 1836 and October 1839. 
-Te Pukurua. Arrowsmith’s 1850 map marks Pukurua on the west bank of the Waimana River in an angle where the river’s course changes from northerly to westerly. Bagnall & Petersen (p. 66) show it in the approximate position of modern Waimana. 16-17 Jan 44. 
-*Te Puna; Tepuna. “… was situated to the north of the Kerikeri Inlet, close to the site of the old mission station at Rangihoua.” (Bagnall & Petersen, p.144n). 23-25 Jul 36; 17 Mar 40. 
+Tepukuotokotahu, the next village (after Hinukuku of the Waiomio valley). Numerous visits are mentioned between September 1836 and October 1839. 
+Te Pukurua. Arrowsmith’s 1850 map marks Pukurua on the west bank of the Waimana River in an angle where the river’s course changes from northerly to westerly. Bagnall & Petersen ( p. 66) show it in the approximate position of modern Waimana. 16-17 Jan 44. 
+*Te Puna; Tepuna. … was situated to the north of the Kerikeri Inlet, close to the site of the old mission station at Rangihoua. (Bagnall & Petersen, p.144n). 23-25 Jul 36; 17 Mar 40. 
 Te Puna. On the southern shore of Tauranga Harbour, west of Te Papa Station. 26-27 Jan 44. 
 Punaruku; Penaruku. On the road past Whangaruru Harbour. 23 Dec 39; 11 Oct 41. 
 Punakitere River. Punakitere River flows northeast before turning east at Ngapuhi south of Kaikohe. 2-? Jun 36. 
@@ -434,40 +427,40 @@ Te Rangaataneiti. Te Rangaataneiti is on the ridge bounded by the Mahakirua and 
 Rangaunu River. Rangaunu Harbour, the large, mangrove-filled tidal inlet north of Kaitaia. 3-4 Apr 39. 
 *Rangitaike River. The Rangitaiki River, one of the main rivers of the Bay of Plenty. Although not mentioned in the Journal, the list of September 1847 mentions the headwaters to the east of Lake Taupo. Colenso thus encountered the river at its middle reaches (1842), its mouth (1844), and its headwaters (Feb. 1847). 6 Jan 42; 3 Jan 44; Feb 47. 
 Rangitikei River. Flows southwards from the Kaimanawa Range. 24 Feb 47; 2-6 Dec 48; 23 Nov 49; 18 & 25 Oct 51; 18-19 Feb 52. 
-Rangitoto. A village very near “Mokorau” on the shore of Ahipara Bay at the southern end of Ninety Mile Beach. 26 Mar 39. 
+Rangitoto. A village very near Mokorau on the shore of Ahipara Bay at the southern end of Ninety Mile Beach. 26 Mar 39. 
 *Rangitukia. Near the mouth of the Waiapu Valley, East Cape. 17-20 Jan 38; 26-29 Nov 41; 21-23 Oct 43. 
-*Rangiwakaaitu Lake. Lake Rerewhakaaitu, the southernmost of the Rotorua lakes. The published versions appear to be errors, as the original spelling was “Rerewakauitu”. 6-7 Jan 42. 
+*Rangiwakaaitu Lake. Lake Rerewhakaaitu, the southernmost of the Rotorua lakes. The published versions appear to be errors, as the original spelling was Rerewakauitu. 6-7 Jan 42. 
 Rangiẁakaoma; Rangiwakaoma. Castle Point, on the Wairarapa Coast. 15 Nov 43; 13-14 Oct 47; 1 Nov 48; 12-14 Mar 50. 
-Raparapahoe. “Ninety Mile Beach, south of Arai, 3½-4 hours’ march from Arai.” 29 Mar, 2 Apr 39. 
-Ratoreka. Later referred to as “Cook’s place” it being the residence of “a man named Cook, formerly in the employ of the mission.” One of the villages near the mission station at Paihia, Bay of Islands. Mentioned several times between February 1835 and July 1839. 
-Ratu, “about ½ a mile distant” (from Pihoi, Whangarei). 10 Dec 39. 
+Raparapahoe. Ninety Mile Beach, south of Arai, 3½-4 hours’ march from Arai. 29 Mar, 2 Apr 39. 
+Ratoreka. Later referred to as Cook’s place it being the residence of a man named Cook, formerly in the employ of the mission. One of the villages near the mission station at Paihia, Bay of Islands. Mentioned several times between February 1835 and July 1839. 
+Ratu, about ½ a mile distant (from Pihoi, Whangarei). 10 Dec 39. 
 *Raukawa. Now a road junction southwest of Hastings and west of the Raukawa Range. 15-16 Sep, 27-28 Dec 47. 
-Rauporua; Rauporoa, “a village about 2 miles distant” (from Kawakawa, Bay of Islands). Not located. 14 Oct, 30 Dec 38. 
-Reinga, Cape. 31 Mar 39. 
+Rauporua; Rauporoa, a village about 2 miles distant (from Kawakawa, Bay of Islands). Not located. 14 Oct, 30 Dec 38. 
+Cape Reinga. 31 Mar 39. 
 *Te Reinga. Te Reinga is at the junction of the Hangaroa and Ruakituri Rivers, the main branches of the Wairoa River, northern Hawke’s Bay. 21-22 Dec 41. 
 Te Reke Manuka. Rekemanuka is marked on Arrowsmith’s 1850 map on the east bank of the Rangitaiki River, and would have been slightly north of modern Te Mahoe. 22 Jan 44. 
 Reporua. Reporoa of modern maps, on the coast south of the Waiapu River mouth. 20-21 Jan 38; 26 Oct 43. 
 *Rimariki Island Off the south head of Whangaruru Harbour. 27 Sep 39. 
 Rimuroa rivulet, nr. Waiohingaanga River. Not located. 
 Ripo. From Colenso’s description, this could have been near the falls on the Wairua River, near Whangarei, but the name has not been located. 24-25 Feb 36. 
-*Rongoakiwa, “road between Te Waipukurau and Te Witi.” From the list of July 1846. Not located and not mentioned in the Journal. 
+*Rongoakiwa, road between Te Waipukurau and Te Witi. From the list of July 1846. Not located and not mentioned in the Journal. 
 *Rotoaira. The small lake to the south of Lake Taupo, lying between Pihonga and Tongariro Mountains. It now forms part of the Tongariro Power Scheme. The village mentioned by Colenso is presumably Poutu (q.v.). 18-19 Feb 47; [29 Nov-1 Dec 49]. 
 *Te Rotoakiwa; Te Roto-a-kiwa lake. Te Roto o kiwa lake is close to the Napier-Wellington highway. The railway line crosses it. 13 Jul 52. 
 *Te Rotoatara Lake. Drained in 1888 by Rev. S. Williams (Bagnall & Petersen, p.208n). It is now marked by a swampy area lying south of a line drawn from Otane to Patangata. 4-5, 12-13 Feb, 23 Sep 45; 29 Jan 46; 13-14 Jan, 16 Dec 48. 
 Te Rotoatara village, On an island in Te Rotoatara Lake. 23 Sep 45; 12-13 Jan, 13-15 Sep 47; 12-15 Jul 50. 
-*Rotokura, “A pool near Te Hawera.” Mentioned in the list of 31 January 1853, but not located. 
-*Rotorua. On a specimen, “Nephrodium hispidum” (WELT p.2603) in the bound volume of ferns. In this context, Colenso probably used Rotorua to refer to the lake rather than the modern town. The date would be from 8 to 12 January, 1842. 
+*Rotokura, A pool near Te Hawera. Mentioned in the list of 31 January 1853, but not located. 
+*Rotorua. On a specimen, Nephrodium hispidum (WELT p.2603) in the bound volume of ferns. In this context, Colenso probably used Rotorua to refer to the lake rather than the modern town. The date would be from 8 to 12 January, 1842. 
 *Ruahine range. That part of the North Island mountain range stretching from the Manawatu Gorge north to the Taihape-Napier highway. 8-10 Feb 45; 24-26 Feb, 31 Dec 47; 8-11 Jan, 27-29 Nov, 13-14 Dec 48; 13-14 Dec 49; 16-17, 27-28 Oct 51; 24-26 Feb 52. 
-*Te Ruaakauia River, “Forest beyond Te Hawera village.” From the list of September 1847. Not located nor mentioned in the Journal. 
+*Te Ruaakauia River, Forest beyond Te Hawera village. From the list of September 1847. Not located nor mentioned in the Journal. 
 Ruatoki, near R. Wakatane The modern Ruatoki (North). 
-Te Ruakaka, Ẁangarei Bay. On Bream Bay, about five miles south of Marsden Point, Whangarei harbour. 16 Feb 42. Also mentioned in the list of 19 November 1844. 
+Te Ruakaka, Ẁangarei Bay. On Bream Bay, about five miles south of Marsden Point, Whangarei harbour. 16 Feb 42 Also mentioned in the list of 19 November 1844. 
 Ruakituri River. The western branch of the Wairoa River, northern Hawke’s Bay. 22 Dec 41. 
 Ruamahanga River. Rises in the northeast Tararua Ranges and after flowing the length of the Wairarapa Valley enters Lake Wairarapa at the southeast corner before again flowing out to Lake Onoke at the coast. (24 Mar 45 as Wairarapa River). 4-5, 9 Apr 45; 24 Mar 46; 7 Apr, 8, 15 Nov 47; 11-12 Apr, 20-21 Nov 48; 22 Mar, 19 Apr 49; 25 Mar 52. 
 *Ruapehu; Ruapahu. Referred to in the list of June 1850. Colenso skirted the eastern base of this, the highest of the volcanic chain southwest of Lake Taupo. 
 *Ruatahuna (hill). The ridge to the east of the Ruatahuna Valley, Urewera. 28 Dec 43. 	
-*Ruatahuna. Arrowsmith’s 1850 map shows Ruatahuna as a hill and a stream, but not as a village. Colenso, however, clearly refers to a village, as well as a district. He placed the village “about 4 miles” from Mangatepa which would correspond with the present settlement of Ruatahuna. 1-3 Jan 42. 
-Te Ruataniẁa, “3 miles from Pipi” downstream on the east side of the Whakatane River. 9 Jan 44. 
-*Te Ruataniẁa (village, Wairarapa). Not located, but a morning’s travel north from Te Kaikokirikiri (Masterton). The location is possibly between Masterton and Mt Bruce. In the list of September 1847 it is mentioned as being at the “head of the Wairarapa Valley”. This is possibly the plantation Te Rua-o-Te-Taniwha near Te Kaikokirikiri mentioned by Bagnall (1954, p.4). 12 May 51. 
+*Ruatahuna. Arrowsmith’s 1850 map shows Ruatahuna as a hill and a stream, but not as a village. Colenso, however, clearly refers to a village, as well as a district. He placed the village about 4 miles from Mangatepa which would correspond with the present settlement of Ruatahuna. 1-3 Jan 42. 
+Te Ruataniẁa, 3 miles from Pipi downstream on the east side of the Whakatane River. 9 Jan 44. 
+*Te Ruataniẁa (village - Wairarapa). Not located, but a morning’s travel north from Te Kaikokirikiri (Masterton). The location is possibly between Masterton and Mt Bruce. In the list of September 1847 it is mentioned as being at the head of the Wairarapa Valley. This is possibly the plantation Te Rua-o-Te-Taniwha near Te Kaikokirikiri mentioned by Bagnall (1954, p.4). 12 May 51. 
 Te Ruataniẁa Plain. Now known as the Takapau Plains (Bagnall & Petersen, p.208n). The low-lying area northwest from Waipawa to the base of the Ruahine Range and traversed by the Waipawa, Tukituki and Tukipo (Avoca) Rivers. Ruataniwha township (Te Ruataniẁa of Colenso) is a short distance west of Waipawa. 5-7, 11 Feb 45; 27 Feb-1 Mar, 29 Dec 47; 30 Oct 51. 
 *Ruaatoki; Ruatoki. Ruatoki on the Whakatane River. 16, 18-20 Jan 44. 
 Te Ruaẁakatorou. Arrowsmith’s 1850 map shows this on the east bank of the Waimana River, Bay of Plenty. 17 Jan 44. 
@@ -478,80 +471,80 @@ Station; Mission Station. See Waitangi.
 
 Table Cape. On the east side of Mahia Peninsula, northern Hawke’s Bay. 2 Nov 43, but no landing. 
 Te Taha. A village on the western shore of Ahuriri Lagoon. 12 Dec 43. 
-Te Taheke. “Te Taheke was situated on the eastern side of Poukawa Lake.” (Bagnall & Petersen, p.232n). 4 Feb 45; 29-30 Jan 46. 
-Tahora. “A deserted village, scene of a massacre, a short distance N. of Wananake.”
+Te Taheke. Te Taheke was situated on the eastern side of Poukawa Lake. (Bagnall & Petersen, p.232n). 4 Feb 45; 29-30 Jan 46. 
+Tahora. A deserted village, scene of a massacre, a short distance N. of Wananake.
 Tauwhara Bay on the coast north of Whananaki Inlet is presumably the same place. 22-23 Sep, 7-8 Oct 41. 
-Tahunaroa. Colenso describes this as on the east bank of the Whakatane, near Papakowatu, i.e. a short distance downstream from the Waimana confluence. 20 Jan 44. 
-Taiamai; Taeamai. Cowan (1922, vol. 1. p.38) shows Taiamai about halfway between Waimate and Ohaeawai, Bay of Islands. “The European township which has appropriated the name (Ohaeawai) should properly be known as Toiamai” (Cowan, s. c. p.68). 5 Feb 37; 19 Aug 38. 
+Tahunaroa. Colenso describes this as on the east bank of the Whakatane, near Papakowatu, (a short distance downstream from the Waimana confluence). 20 Jan 44. 
+Taiamai; Taeamai. Cowan (1922 - vol-1 p.38) shows Taiamai about halfway between Waimate and Ohaeawai, Bay of Islands. The European township which has appropriated the name (Ohaeawai) should properly be known as Toiamai (Cowan, s. c. p.68). 5 Feb 37; 19 Aug 38. 
 Taihoata River. A misspelling for Kaihoata. 
 Taika. Otaika is about four miles south of Whangarei. 12-14 Dec 39; 20 Jul 41. 
 Taikumikumi. This was on the Kawakawa River, Bay of Islands, between Opaohu and Kawakawa, about half a mile from the latter, and may have been Colenso’s customary landing place for his regular missionary visits to Kawakawa and Waiomio. 10 Oct 40; 17 Jan 41. 
-*Takamaitua, Between Cape Turnagain & Castle Point. “Takamaitua was a creek one hour forty minutes south of Pakuku and would therefore be about halfway between Tautane and Akitio.” (Bagnall & Petersen, p.217n). Mentioned in the list of July 1846. 
+*Takamaitua, Between Cape Turnagain & Castle Point. Takamaitua was a creek one hour forty minutes south of Pakuku and would therefore be about halfway between Tautane and Akitio. (Bagnall & Petersen, p.217n). Mentioned in the list of July 1846. 
 Te Takapau. Te Takapau was situated on the Ruatahuna Stream, not far south of Te Umuroa, Urewera. (Bagnall & Petersen, p.176). Arrowsmith’s 1850 map shows Te Takapau on a stream below a mountain Pukehuia, presumably Whakataka. 
 Te Takapau, A small village on Pahawa River. Takapau is on the deep bend of the Pahaoa River at the confluence of the Waitetuna Stream just north of Hinekura. 19-20 Apr 48; 19-20 Mar 50. 
 Takou. Takou Bay, north of the Bay of Islands. 11 Apr 39. 
-*Tamaki Creek, River Thames, Jan 43. 
+*Tamaki Creek. River Thames. Jan 43. 
 Tamaki River, Auckland. In 1843, the Firth of Thames included the Hauraki Gulf. The locality occurs on a specimen of Gymnogramme leptophylla at WELT and is also mentioned in the list of 10 May 1843. 
 *Tamoki River; Tamaki. The Tamaki River flows south of Tahoraiti to join the Manawatu by the rifle range at the end of the Totaramahanga Road, a few miles south of Dannevirke. 17-18 Mar 52. 
-*Tamatarau. Tamaterau, on the north shore of Whangarei Harbour east of Onerahi Peninsula. It was here that Colenso found the “Tamil Bell”. 29-30 Sep-1, 2 & 4 Oct 41; 16-17 Feb,?Oct 42. 
+*Tamatarau. Tamaterau, on the north shore of Whangarei Harbour east of Onerahi Peninsula. It was here that Colenso found the Tamil Bell. 29-30 Sep-1, 2 & 4 Oct 41; 16-17 Feb,?Oct 42. 
 *Te Tamumu. On the Tukituki River east of the confluence with the Waipawa. 24-25 Mar 48; 12-13 Apr 50; 14-20 Jul, 20-23 Aug 52. 	
-*Tanenuiarangi. “site of house now under freezing works” (Buchanan p.161) i.e. on the present site of Hastings. 1 Mar 45; 26 Jan 47; 8 Mar 49. 
-Tangiteroria, “Mr Buller’s Station.” On the Wairoa River, Northland, on the Dargaville-Whangarei Road and the site of Buller’s Wesleyan Mission. Not mentioned by name by Colenso. 11-12 Feb 44. 
-Tangoiro. “An hour’s march north of Waihirere Waterfall,” i.e. between Mawhai Point and Anaura Bay. 
+*Tanenuiarangi. site of house now under freezing works (Buchanan p.161) (on the present site of Hastings). 1 Mar 45; 26 Jan 47; 8 Mar 49. 
+Tangiteroria, Mr Buller’s Station. On the Wairoa River, Northland, on the Dargaville-Whangarei Road and the site of Buller’s Wesleyan Mission. Not mentioned by name by Colenso. 11-12 Feb 44. 
+Tangoiro. An hour’s march north of Waihirere Waterfall, (between Mawhai Point and Anaura Bay). 
 *Tangoio. (Lagoon and River) On the coast of Hawke’s Bay, 14 miles north from Napier. 15 Jun, 24-25 Jul 45; 5-7 Jan, 4-8 Jun, 25 & 27-30 Nov 46; 15-16 & 18-21 Jun, 28 Aug-1 Sep 47; 9-10 & 12-15 Feb, 10-14 Aug, 14-16 Oct 48; 20-23 Jan, 15-18 Jun 49; 12-14 Jan, 10-15 May, 18-21 Jun, 11-14 Oct, 21-23 Dec 50; 3-5 Mar, 4-5 Jun, 29-30 Jul, 29-30 Sep, 1-2 Oct, 10-11 & 13 Nov 51; 27 & 30 Jan, 7-9 Jun, 12-13 & 24-26 Aug 52. 
 *Tapatahi. Inland from Waipiro (Open) Bay, East Coast. Arrowsmith’s 1850 map indicates it on the high land between Waipiro and Tokomaru Bays. 22 Jan 38; 2 Dec 41. 
-*Tapatapauma. Bagnall & Petersen (p. 136n 25) identify this locality with a quarry in the angle between the Gisborne-Napier via Hangaroa State Highway and Parikanapa Road, two miles west of Waerengaokuri. If this identification is correct, which seems likely, then the “rivulet” to which Colenso refers is presumably the Waikoko Stream. 20-21 Dec 41. 
-Tapere, “About 8 miles from the (Paihia) Station.” On the way to Waikare, but not located. 18 Sep 36; 1 Jan, 10 Sep 37; 25 Mar 38; 13 Jan 39. 
-Tapiri. Described by Colenso (Papers I, p.95) as “the pa of the profess(in)g Chr(istian) Natives of Matamata” and about a mile distant, i.e. close to Waharoa, Thames Valley. 20-21 Jan 42; 27-29 Jan 44. 
+*Tapatapauma. Bagnall & Petersen ( p. 136n 25) identify this locality with a quarry in the angle between the Gisborne-Napier via Hangaroa State Highway and Parikanapa Road, two miles west of Waerengaokuri. If this identification is correct, which seems likely, then the rivulet to which Colenso refers is presumably the Waikoko Stream. 20-21 Dec 41. 
+Tapere, About 8 miles from the (Paihia) Station. On the way to Waikare, but not located. 18 Sep 36; 1 Jan, 10 Sep 37; 25 Mar 38; 13 Jan 39. 
+Tapiri. Described by Colenso (Papers I, p.95) as the pa of the profess(in)g Chr(istian) Natives of Matamata and about a mile distant, (close to Waharoa), Thames Valley. 20-21 Jan 42; 27-29 Jan 44. 
 *Tapuaeharuru, Plains head of Wairarapa Valley. Not located nor mentioned in the Journal. 
 *Tapuata Forest, R. Manawatu. This name is preserved as a locality in Dannevirke County, a railway siding between Dannevirke and Woodville. Formerly called Tamaki according to Dollimore. Mentioned by Colenso in the list of 31 January 1853. 
-Tarare. “On the east bank of the Rangitikei north of the Kawhatau junction” (Bagnall & Petersen, p.292n). Colenso states that he followed the west bank. 5 Dec 48. 
+Tarare. On the east bank of the Rangitikei north of the Kawhatau junction (Bagnall & Petersen, p.292n). Colenso states that he followed the west bank. 5 Dec 48. 
 *Tararua Range. The southern end of the central North Island mountain chain, from the Manawatu Gorge southwards. Colenso’s acquaintance with the range was limited to the road, which was already under construction at the time of his first visit, over the Rimutaka Saddle. 5- Nov 47; 17-18 Apr 49. 
-Tarawera, “A well-fenced pa.” On the upper reaches of the Kawakawa River but not located. 1 Jun 36. 
+Tarawera, A well-fenced pa. On the upper reaches of the Kawakawa River but not located. 1 Jun 36. 
 Tarawera Lake. Rotorua District. 7 Jan 42. 
-*Tarawera. On the Taupo-Napier Road at the Waipunga River. Bagnall & Petersen note (p. 242n) that “the village was situated on a terrace below the site of the old hotel.” 25-29 Apr 46; 12-15 Feb 47; 18-21 Feb 48; 25-29 Jan, 7-10 Dec 49; 5-8 Oct 50. The 1847 dates refer to Pirapirau, another village in the Tarawera district (In Memoriam, p.34). 
+*Tarawera. On the Taupo-Napier Road at the Waipunga River. Bagnall & Petersen note ( p. 242n) that the village was situated on a terrace below the site of the old hotel. 25-29 Apr 46; 12-15 Feb 47; 18-21 Feb 48; 25-29 Jan, 7-10 Dec 49; 5-8 Oct 50 The 1847 dates refer to Pirapirau, another village in the Tarawera district (In Memoriam, p.34). 
 *Taruarau River; Taruarau Plains. The river rises in the Kaimanawa Mountains and joins the Ngaruroro. It forms part of the northern boundary of the Ruahine Range. The plains would seem to refer to the high downland between the Ruahine and Kaimanawa Ranges. 17 Oct 51 (river); 17-18 Feb 52 (plains). 
 Taruheru. Poverty Bay. The name is preserved in a stream, a tributary of the Turanganui River. Porter (1974, p.83n) is unable to locate the village precisely. 27 Jan 38. 
 Tauaki. Arrowsmith’s 1850 map shows Tauaki on the west bank of the Waikare River, and north of the Maungapohatu ridge. The Waikare crossing used by Colenso seems to have been near, if not at, Neketuri, which places Tauaki slightly downstream from the crossing. It is not, apparently, the Tauaki slightly north of Pinaki. 12 Jan 44. 
 Tauanui. The Tauanui River drains into the Ruamahanga near the outlet from Lake Wairarapa. 6 Nov 45; 17-18 Mar, 16 Sep 46; 15 Apr 47; 24 May, 13-14 Nov 48; 29 Mar 49; 22 Apr 51. 
-Tauatepopo. “part of Poukawa Block” (Buchanan, p.181). Buchanan’s grid reference would place the village immediately north of Colin White’s Road at Te Hauke, ENE of Poukawa Lake. 12-13 Mar, 9-10 Jul 52. 
+Tauatepopo. part of Poukawa Block (Buchanan, p.181). Buchanan’s grid reference would place the village immediately north of Colin White’s Road at Te Hauke, ENE of Poukawa Lake. 12-13 Mar, 9-10 Jul 52. 
 *Taupo Lake. 16-18 Feb 47; 1-4 Dec 49. 
 *Taupo Plains. Roughly the Rangitaiki Plains to the east of Lake Taupo. 15 Feb 47. 
 *Tauranga. Bay of Plenty. 5-12 Jan 38; 14-19 Jan 42; 24 Jan 44. 
 Tauranga Harbour. Bay of Plenty. 19 Jan 42; 15-18 Oct 43; 24-27 Jan 44. 
 *Tautane; Tautaane. The Tautane River reaches the sea a mile or so from Cape Turnagain. 10 Mar 45; 9 Oct 47; 8-9 Jun, 30 Oct 48; 4 May 49; 8-9 Mar 50; 2-3 Apr 51; 23 Apr 52. 
 *Tauẁarenikau River. The river rises in the Tararua Ranges and flows between Carterton and Featherston before entering the northeast corner of Lake Wairarapa. The older spelling of Tauherenikau has been replaced by Tauwharenikau which conforms with Colenso’s spelling. 18-19 Apr 49. 
-Taẁanaẁana, “One of our old sleeping places….” On the wrapping of Colenso 4832, an hepatic from “dense forest, nr. Te Hawera” this name appears. It has not been located but as it was the overnight stop between Te Hawera and Te Kaikokirikiri, it was possibly in the vicinity of Ekatahuna. 24 Mar 52. 
+Taẁanaẁana, One of our old sleeping places…. On the wrapping of Colenso 4832, an hepatic from dense forest, nr. Te Hawera this name appears. It has not been located but as it was the overnight stop between Te Hawera and Te Kaikokirikiri, it was possibly in the vicinity of Ekatahuna. 24 Mar 52. 
 Tauwenua (Hikurangi). This corresponds either to Tauanui (1150 feet) or Tautoro No. 2 (1522 feet) to the west of the upper Punakitere River, and SSE of Kaikohe. 5 Jun 36. 
 Tawera, WekaruatapuProbably in the vicinity of the present Matamau. There is also a Tawera just north of Mt Bruce, in the Wairarapa. 
-*Temateatai, “Wangaruru Bay, Octobr., 1841.” Tamatateatai Point is a prominent peninsula on the west side of Whangaruru Harbour forming the northern side of Punaruku Estuary. The locality appears in an item 409 of an undated list. 
+*Temateatai, Wangaruru Bay, Tamatateatai Point is a prominent peninsula on the west side of Whangaruru Harbour forming the northern side of Punaruku Estuary. The locality appears in an item 409 of an undated list.  Oct 1841 
 Thames River This included not only the present Thames Valley but also the Firth of Thames and Hauraki Gulf. 
 Tihi. On the Ruamahanga River, three hours’ journey from Te Kaikokirikiri, but not located. 12 Apr 48. 
 Tirohanga. Tirohanga Stream is a southern tributary of the Kawakawa River. 16 Oct 36; 15 Jan, 12 Mar 37. 
 Titiokura. On Highway 5 from Napier to Taupo and at the saddle between Te Waka and Maungaharuru Ranges. 23 Apr, 10 Dec 46; 11 Feb 47; 21 Feb 48; 9-10 Oct 50. 
-Titirangi. “Walked to the Waimate (from Paihia), by way of Titirangi, 15 miles.” Not located. 6 Sep 36. 
-Toanga. In Poverty Bay and described as “3 miles from Kaupapa” and “2 miles from Taruheru” but not located. Porter (p. 83n) was also unable to locate it precisely. 27-29 Jan 38; 11-13 & 15 Dec 41;
+Titirangi. Walked to the Waimate (from Paihia), by way of Titirangi, 15 miles. Not located. 6 Sep 36. 
+Toanga. In Poverty Bay and described as 3 miles from Kaupapa and 2 miles from Taruheru but not located. Porter ( p. 83n) was also unable to locate it precisely. 27-29 Jan 38; 11-13 & 15 Dec 41;
 *Tohora, E. Coast. Appears in the draft Journal of 22 May 1841 and in the list of 30 July 1844 and intended for Tahora (q.v.). 
 *Tohoranui. Tahoranui River drains into Taronui Bay at the south end of Takou Bay. 11 Apr 39. 
-Toiti Village. “Just short of the banks of the Waipa River” (Bagnall & Petersen, p.127). 26-27 Jan 42. 
-Tokaroa, “A peculiarly craggy rock.”Honeycomb Rock? On the Wairarapa coast between Flat Point and the Pahaoa River. 24 Nov 45. 
-Toki Village, The, on Wairua River, Ẁangarei. Three hours upstream from Aotahi and possibly in the vicinity of modern Titiko, although this is now on the Mangakahia River branch of the Wairoa catchment. 23 Feb 35. 
+Toiti Village. Just short of the banks of the Waipa River (Bagnall & Petersen, p.127). 26-27 Jan 42. 
+Tokaroa, A peculiarly craggy rock.Honeycomb Rock? On the Wairarapa coast between Flat Point and the Pahaoa River. 24 Nov 45. 
+Toki Village, on Wairua River, Ẁangarei. Three hours upstream from Aotahi and possibly in the vicinity of modern Titiko, although this is now on the Mangakahia River branch of the Wairoa catchment. 23 Feb 35. 
 Tokomaru. Tokomaru Bay, East Coast. 22-24 Jan 38; 2-4 Dec 41; 27 Oct 43. 
 *Tolago Bay. Tolaga Bay. North of Poverty Bay. 24-25 Jan 38; 7-9 Dec 41. 
-Tongake, “The principal village of the Ngunguru District.” Bagnall & Petersen (p. 38) show it on the north head of Ngunguru River, but this would scarcely seem an hour’s journey from Tutukaka as described by Colenso. 18-19 Dec 39; 24-27 Sep, 5-6 Oct 41. 
+Tongake, The principal village of the Ngunguru District. Bagnall & Petersen ( p. 38) show it on the north head of Ngunguru River, but this would scarcely seem an hour’s journey from Tutukaka as described by Colenso. 18-19 Dec 39; 24-27 Sep, 5-6 Oct 41. 
 *Tongariro, Base of. Colenso’s route lay to the east of the central volcanoes both on his southerly (1847) and northerly (1849) journeys. 
 Totara. Totara North is on the west shore of Whangaroa Harbour. 9 Apr 39. 
 Tourangatira. On the Kawakawa River but not located. 1 Jun 36. 
-*Tuaraiawa River, “Nr. Patea village.” See Oturereawa. 
+*Tuaraiawa River, Nr. Patea village. See Oturereawa. 
 Tuarau Village, On Wangaroa River. Not located. It was presumably on the northern Whangaruru Harbour. 15 Apr 35. 
 Tuatini. On Tokomaru Bay, East Coast. 4 Dec 41; 27 Oct 43. 
-Tuhirangi. A “small village” three hours’ march south from Oroi and before Cape Palliser, but exact location not established. 17 Apr 51; 7 Apr 52. 
+Tuhirangi. A small village three hours’ march south from Oroi and before Cape Palliser, but exact location not established. 17 Apr 51; 7 Apr 52. 
 Tuhitarata. McMasters’ station on the Ruamahanga River close to the entrance to Lake Wairarapa. 16 Sep 46; 24-25 May, 14 Nov 48; 22 Apr 51; 1 Apr 52. 
 *Tuingara. A small cove a few miles south of Paoanui Point on the coast between Cape Kidnappers and Black Head. 21-22 Aug 46; 4-5 Oct 47; 27 Oct 48; 5 Mar 50; 26-27 Mar 51; 1 May 52. 
 *Tukituki River. The southernmost of the main central Hawke’s Bay rivers, flowing east then north to enter the sea at the southern end of Hawke Bay. 1 Mar 45. 
 Tukituki Village. Probably Patangata (q.v.). 28 May 47. 
-Tukuwahine, “A village about 3 miles from Te Kaikokirikiri (in an ESE direction).” Not located precisely, but was clearly close to Masterton. Bagnall & Petersen (p. 218) show it on the west bank of the Ruamahanga River and almost due east of Te Kaikokirikiri. 
-Tunanui. Arrowsmith’s 1850 map marks Tunanui on the east bank of the Whakatane River downstream from the Waikare Stream junction. Bagnall & Petersen (p. 66) show it on the west bank. 15-16 Jan 44. 
+Tukuwahine, A village about 3 miles from Te Kaikokirikiri (in an ESE direction). Not located precisely, but was clearly close to Masterton. Bagnall & Petersen ( p. 218) show it on the west bank of the Ruamahanga River and almost due east of Te Kaikokirikiri. 
+Tunanui. Arrowsmith’s 1850 map marks Tunanui on the east bank of the Whakatane River downstream from the Waikare Stream junction. Bagnall & Petersen ( p. 66) show it on the west bank. 15-16 Jan 44. 
 Tuparoa,Or, Te ari aẁai. South of Reporoa, East Cape, on the coast between Kouruamoa and Kaimoho Points. 20-21 Jan 38. 
 Tupuaeharuru,Plains head of Wairarapa Valley. Not located. 
 *Turakirae,SW head of Palliser Bay. 
@@ -564,52 +557,47 @@ Tureawa River, near Patea. See Otureawa.
 Turnagain, Cape. See Cape Turnagain. 
 *Tutaekuri River. The northernmost of the main rivers of central Hawke’s Bay. It rises in the Kaweka Range and reaches the sea south of Napier. In Colenso’s time it turned north to discharge into the southern end of Ahuriri Lagoon. 13 Feb 52. 
 Tutaimatai. Near the north end of Whangaruru Harbour, on the road to Russell. 11 Oct 41; 21 Feb 42. 
-Tutangi, 
-“left (Waikino) and rowed to Tutangi.”
-Not further located. 1 Jan 37. 
-*Tutukaka Harbour. 
-About half a mile north of Ngunguru River. 19 Dec 39; 24 Sep, 6 Oct 41; Oct 42. 
-*Tututarata. “Tututarata was on the range between Rangitaiki and the Mangawiri Stream” (Bagnall & Petersen, p.176n quoting Best). A stream still bears the name. 1-2 Jan 44. 
-Tuẁanui – by a small stream, Between Tangoio and Waikari. I can find no evidence of this …. But the coast here has been much altered by earthquake. 7-8 Jan 46. 
+Tutangi, left (Waikino) and rowed to Tutangi. Not further located. 1 Jan 37. 
+*Tutukaka Harbour. About half a mile north of Ngunguru River. 19 Dec 39; 24 Sep, 6 Oct 41; Oct 42. 
+*Tututarata. Tututarata was on the range between Rangitaiki and the Mangawiri Stream (Bagnall & Petersen, p.176n quoting Best). A stream still bears the name. 1-2 Jan 44. 
+Tuẁanui, by a small stream, Between Tangoio and Waikari. I can find no evidence of this …. But the coast here has been much altered by earthquake. 7-8 Jan 46. 
 Tuwatapipi Stream. Not located but described as being between Waikare and Whangaruru Inlet. 14-15 Apr 35. 
 {U}
-*Uawa RiverThe river flows north to south following the coastline of Anaura and Tolago Bays. 24-25 Jan 38; 6-9 Dec 41; 28-30 Oct 43. 
-Uawa, “a small village” (apparently on the west shore of Palliser Bay). 26-27 Oct 47; 1-2 May 48. 
+*Uawa River. The river flows north to south following the coastline of Anaura and Tolago Bays. 24-25 Jan 38; 6-9 Dec 41; 28-30 Oct 43. 
+Uawa, a small village (apparently on the west shore of Palliser Bay). 26-27 Oct 47; 1-2 May 48. 
 *Te Umukiwi, Tutaekuri. Occurs in the list of 31 January 1853 but not located and not mentioned by Buchanan. 
 Umuroa. This was on the way from Paihia to Paroa Bay, and is possibly to be equated with Oneroa Bay, Bay of Islands. 3 Jul 36. 
 Te Umutaoroa. Some six miles north of Dannevirke on a west branch of the Mangatera Stream and close to the foothills of the Ruahine Range. 14 Mar 49. 
 *Te Unuunu. Te Unu Unu Stream reaches the sea at Flat Point, Wairarapa Coast. 7 Sep 46; 3 Nov 48; 15 Mar 50; 14 Apr 52. 
-Upokohutia, “A small clump of Karaka trees.” “Upokohutia would probably be the creek at the south end of Otahome flat, north of Waimimi.” (Bagnall & Petersen, p.219n). 
+Upokohutia, A small clump of Karaka trees. Upokohutia would probably be the creek at the south end of Otahome flat, north of Waimimi. (Bagnall & Petersen, p.219n). 
 Te Upokokirikiri, On the eastern shore of Lake Onoke, Palliser Bay. Arrowsmith’s 1850 map shows Poko kirikiri about half way along the shore. 2 Apr 45; 4-6 Mar 46; 2 Apr 49. 
 Urewera. Although Colenso does not use this district name, it has been included as not only was Colenso the first pakeha to visit the area, but he was the first to map it, however, roughly, and the first to make botanical collections. For the present purposes the modern limits of the National Park are recognized. 23 Dec 41-4 Jan 42; 19 Dec 43-16 Jan 44. 
 Uriti. Uriti Bay is on the east side of Pomare Bay, southeast of Russell, Bay of Islands. 30 May 36. 
 *Te Uruti. Uruti Point, south of the Whareama River, Wairarapa coast. 14-15 Oct 47, although this is the only mention in the Journal, the name appears in the list of July 1846 and would have been passed on many occasions. 
-Uruhou. Arrowsmith’s 1850 map shows “Uruhoa” on the east bank at the mouth of the Wairoa River, Hawke’s Bay. Colenso places it three miles inland. 15-18 Dec 43. 
+Uruhou. Arrowsmith’s 1850 map shows Uruhoa on the east bank at the mouth of the Wairoa River, Hawke’s Bay. Colenso places it three miles inland. 15-18 Dec 43. 
 {W}
 *Wahanga,A river on the E. Coast, 20 miles N. of Mataikona. This version of Owahanga occurs in the list of 30 July 1844. The river is about nine miles north of Mataikona. 
-Wahapu, “The residence of Mr Mair.”Te Wahapu Bay opens on to Veronica Channel northwest of Okiato, Bay of Islands. Colenso mentions six visits between 1836 and 1839. 
-*Wahianoa; Wahienoa; Wahieanoa, “A spot on the hills where there was water.”Between the Kaiwaka River and Titiokura, probably on the Maungaharuru Range. 10-11 Feb 47; 15-16 & 20-21 Feb 48. 
+Wahapu, The residence of Mr Mair.Te Wahapu Bay opens on to Veronica Channel northwest of Okiato, Bay of Islands. Colenso mentions six visits between 1836 and 1839. 
+*Wahianoa; Wahienoa; Wahieanoa, A spot on the hills where there was water.Between the Kaiwaka River and Titiokura, probably on the Maungaharuru Range. 10-11 Feb 47; 15-16 & 20-21 Feb 48. 
 *Waiapu River. The major river reaching the coast a few miles south of East Cape. 17-20 Jan 38; 26 Nov-1 Dec 41; 21-23 & 25-26 Oct 43. 
 Waiariki. The Waiariki River joins the Waiotu River close to where Highway 1 crosses it from Hukerenui to Whangarei. 19-20 Feb 36. 
 *Waiariki, Cook’s Straits. Was situated at the mouth of the Waiariki Stream which flows south a mile to the west of Tongue Point on the southern coast of the Wellington Peninsula. 8-9 May 48. 
 Waiaruhe. The Waiaruhe River flows north to join the Waitangi at Puketona, Bay of Islands. 7 Sep 36. 
 *Te Waiau River. From Colenso’s account, it is clear that this name was applied to the stretch of the Waikaretaheke River between the present Waiau and the Wairoa. 18 Dec 43. 
 Waiaua. Waiaua Bay is at the northwest end of Takou Bay, north of the Bay of Islands. 11 Apr 39. 
-Wai Haruru Stream. Waiharuru Stream is a tributary of the Hinemaiaia on the eastern side of Lake Taupo. 
-16 Feb 47. 
-Waihi. Now known as Little Waihi at Town Point, Bay of Plenty. Arrowsmith’s 1850 map indicates Waihi further east than Colenso’s time intervals allow. 
-Waihirere, “A beautiful waterfall.”
-Waihirere Stream is on the coast between Mawhai Point and Anaura Bay, East Coast. 4 Dec 41. 
+Wai Haruru Stream. Waiharuru Stream is a tributary of the Hinemaiaia on the eastern side of Lake Taupo. 16 Feb 47. 
+Waihi. Now known as Little Waihi at Town Point, Bay of Plenty. Arrowsmith’s 1850 map indicates Waihi further east than Colenso’s time intervals allow.. 
+Waihirere, A beautiful waterfall. Waihirere Stream is on the coast between Mawhai Point and Anaura Bay, East Coast. 4 Dec 41. 
 Waiho River. The Waihou River, Northland, a main branch of the Hokianga. 21 Mar 39. 
 *Waiho River. Te Waihou River. The Waihou River, Thames. 20 Jan 42; 27 Jan 44. 
-Waihoa“Waihoa was approximately midway between Tuatini and Mawhai Point, the southern extremity of Tokomaru Bay” (Bagnall & Petersen p.136n). The Waihoa Stream reaches the sea towards the southern end of Tokomaru Bay. 4 Dec 41. 
-Waihua, “A few miles S. of Poututu.”The Waihua River, northern Hawke’s Bay. 17 Aug 45. 
-Te Waiiti; Te Waiti, “4 miles from Pihoi.”The Te Waiiti Stream joins Limeburners Creek close to Highway 1, south of Whangarei. 20-22 Feb 36; 11-12 & 14 Dec 39. 
+WaihoaWaihoa was approximately midway between Tuatini and Mawhai Point, the southern extremity of Tokomaru Bay (Bagnall & Petersen p.136n). The Waihoa Stream reaches the sea towards the southern end of Tokomaru Bay. 4 Dec 41. 
+Waihua, A few miles S. of Poututu.The Waihua River, northern Hawke’s Bay. 17 Aug 45. 
+Te Waiiti; Te Waiti, 4 miles from Pihoi.The Te Waiiti Stream joins Limeburners Creek close to Highway 1, south of Whangarei. 20-22 Feb 36; 11-12 & 14 Dec 39. 
 *Te Waiiti. Te Whaiti on the Whirinaki River, inland Bay of Plenty. 4-5 Jan 42; 30 Dec 43. 
-Waiiti, Te. District. The present Te Whaiiti, on the Whakatane River. 
+Te Waiiti District. The present Te Whaiiti, on the Whakatane River. 
 *Waikaha Stream. No longer marked on the maps but appears to be the stream draining the valley southeast of Pakipaki into the old course of the Ngaruroro in the vicinity of Havelock North. The stream has no doubt been absorbed by the drainage ditch system. Buchanan cites a stream in this vicinity. 15 Nov 49; 17 Jan 52. 
-*Te Waikamaka River, “E. side of Ruahine.” The Waikamaka River joins the Rangitikei north of the Mokai Patea ridge on the western side of the Ruahine Ranges. Colenso appears to have made an uncharacteristic slip in the reference which is in the list of 31 January 1853. 
-Waikaraka; Te Karaka (?)On Whangarei Harbour, about 1½ miles from Tamaterau, and at the eastern base of Onerahi Peninsula. 4 Oct 41; [17 Feb 42; Te Karaka]. 
+*Te Waikamaka River, E. side of Ruahine. The Waikamaka River joins the Rangitikei north of the Mokai Patea ridge on the western side of the Ruahine Ranges. Colenso appears to have made an uncharacteristic slip in the reference which is in the list of 31 January 1853. 
+Waikaraka (Te Karaka (?) On Whangarei Harbour), about 1½ miles from Tamaterau, and at the eastern base of Onerahi Peninsula. .4 Oct 41; [17 Feb 42; Te Karaka]. 
 *Waikare Lake. Lake Waikaremoana in the Urewera National Park. 24-30 Dec 41; 20-28 Dec 43. 
 *Waikare, Bay of Islands. On the Waikare River at the head of the inlet of the same name on the inner south shore of the Bay of Islands. 
 Waikare River, Urewera. The stream flowing north from Maungapohatu to join the Whakatane. Not mentioned by Colenso, but it is marked on Arrowsmith’s 1850 map and I have used it here as a reference to other place names. 
@@ -619,20 +607,20 @@ Waikaretaheke River. The outfall of Lake Waikaremoana. Colenso uses the name onl
 Waikino. Waikino Creek joins Waikare Inlet east of the confluence with the Kawakawa River, Bay of Islands. Twelve visits are recorded between May 1835 and July 1840. 
 Te Waimana River; Te Waimana District. The Waimana River is a major eastern tributary of the Whakatane, Bay of Plenty. 16-18 Jan 44. 
 *Waimarama,About 15 miles south of Cape Kidnappers. 8 Dec 43; 1-4 Mar, 3-4 Nov 45; 10-11 Feb, 18-20 Aug 46; 15-16 Jan, 27-28 May, 1-2 Oct 47; 15-16 Jun, 25-26 Oct 48; 10-15 May, 18-22 Oct 49; 2-4 Mar, 6-9 Jul, 28-29 Nov 50; 21-25 Mar, 6-8 Aug, 27-29 Dec 51; 4-6 May, 12-15 Jun, 17-18 Aug, 8-11 Nov 52. 
-*Waimarara,A little stream in Palliser Bay. Bagnall & Petersen (p. 218) indicate Waimarara Stream on the west shore of Palliser Bay, approximately in the position of the Little Mukamuka Stream. Older maps mark a stream approximately half way between Little Mukamuka and Cape Turakirae. 19-20 Apr, 27 Oct 47; 18-19 May 48. 
-Waimarino, “On the shore of Taupo Lake.”The Waimarino River flows into the southeastern corner of Lake Taupo. The village may be the same as that later called Korohe (q.v.) by Colenso. 17 Feb 47. 
+*Waimarara,A little stream in Palliser Bay. Bagnall & Petersen ( p. 218) indicate Waimarara Stream on the west shore of Palliser Bay, approximately in the position of the Little Mukamuka Stream. Older maps mark a stream approximately half way between Little Mukamuka and Cape Turakirae. 19-20 Apr, 27 Oct 47; 18-19 May 48. 
+Waimarino, On the shore of Taupo Lake.The Waimarino River flows into the southeastern corner of Lake Taupo. The village may be the same as that later called Korohe (q.v.) by Colenso. 17 Feb 47. 
 Waimata River. This river reaches the sea at slightly over half way travelling north from Akitio to Tautane on the Wairarapa Coast. 22-23 Apr 52. 
 *Waimate. Waimate North, on the Waimate River, west of the Bay of Islands and 3½ miles north of Ohaeawai. This was the first inland European settlement in New Zealand and Bishop Selwyn’s headquarters. Colenso records several visits between October 1835 and February 1840. He was in residence there in 1843-4. 
-Waimimiha, “A small stream.” The Waiamimi Stream south of Castle Point and a short distance north of the Whareama River on the Wairarapa coast. 1-3 Nov 48. 
+Waimimiha, A small stream. The Waiamimi Stream south of Castle Point and a short distance north of the Whareama River on the Wairarapa coast. 1-3 Nov 48. 
 Wainui. On a small bay of the same name east of Whangaroa Harbour, Northland. 10 Apr 39. 
 *Te Waiohingaanga River. Now known as the Esk, entering the sea at Petane between Tangoio and Napier. 22 Apr 46; 9-10 Feb 47. 
-Te Waiokongenge. A camping spot “Half-way down the (Ruahine) range”, below Te Atuaomahuru on the east side. 22 Feb 47. 
-*Waiomio; Whaiomio, “A valley containing several villages” (of which only Hinekuru and Tapukuotokoahu are named by Colenso). In the first few instances he treats Waiomio as a village name. The Waiomio valley is almost due south of Kawakawa. From 1836, this district was Colenso’s main missionary responsibility and he made visits at approximately two-weekly intervals. 
+Te Waiokongenge. A camping spot Half-way down the (Ruahine) range, below Te Atuaomahuru on the east side. 22 Feb 47. 
+*Waiomio; Whaiomio, A valley containing several villages (of which only Hinekuru and Tapukuotokoahu are named by Colenso). In the first few instances he treats Waiomio as a village name. The Waiomio valley is almost due south of Kawakawa. From 1836, this district was Colenso’s main missionary responsibility and he made visits at approximately two-weekly intervals. 
 Waioreore. This is described as a small village on the route between the Wairua and Kawakawa Rivers. It would appear to have been near the head of the Waiomio Valley, possibly in the vicinity of Towai. 26 Feb 36; 13 Feb 44. 
-Waiorongo, “nr. Castle Point.”Near the mouth of the Wakataki River a few miles north of Castle Point, on the Mataikona Road, Wairarapa Coast. 15 Nov 43; 13-14 Mar, 26 Nov 45; 23-24 Feb, 3 Sep 46. 
+Waiorongo, nr. Castle Point.Near the mouth of the Wakataki River a few miles north of Castle Point, on the Mataikona Road, Wairarapa Coast. 15 Nov 43; 13-14 Mar, 26 Nov 45; 23-24 Feb, 3 Sep 46. 
 Waipa River. One of the main tributaries of the Waikato, joining it at Ngaruawahia. 24 Jan 42; 30 Jan 44. 
 Waipahirere. A camping spot 2½ hours’ march south of Hukatere on Ninety Mile Beach, Northland. 28-29 Mar 39. 
-Waipaoa River; Waipaua River; Waipoua River, “Our old sleeping place.”
+Waipaoa River; Waipaua River; Waipoua River, Our old sleeping place.
 The Waipawa River, Hawke’s Bay. 7 & 11 Feb 45; 29-31 Dec 47; 29-31 Dec 49; 30 Oct 51. 
 Waipapa Stream. A stream named Waipapa joins the Waionepu River south of Maungatapere near Whangarei. 22 Feb 36. 
 Waiparati, Te, near Tarawera. Not located, but Tarawera is the locality on the Taupo-Napier road. 
@@ -640,41 +628,41 @@ Waiparati, Te, near Tarawera. Not located, but Tarawera is the locality on the T
 Waipaua River. See Waipaoa River. 
 Waipawa River. A tributary of the Tukituki. It rises in the Ruahine Range, is joined by the Makororo and flows into the main stream at Waipawa. 
 *Waipoua River. See Waipaoa River. 19-20 Nov 49; 30 Oct 51. 
-Waipoua River,Head of Wairarapa Valley. Rises in the Tararua Ranges and joins the Ruamahanga at Masterton. Not mentioned in the Journal and appearing as item 691 in an undated list. 
-*Waipuakakahu, “Half-way between Ẁangarei & Bay of Islands.”The Waipuakakahu Stream joins the Waiotu River at Waiotu on the Kawakawa-Whangarei Road, 17 miles north of Whangarei. The date April 1843 appears on a specimen of “Lomaria fluviatilis” (WELT p.3320) and the locality also occurs in the list of 30 July 1844. 
+Waipoua River,Head of Wairarapa Valley. Rises in the Tararua Ranges and joins the Ruamahanga at Masterton. Not mentioned in the Journal and appearing as item 691 in an undated list..
+*Waipuakakahu, Half-way between Ẁangarei & Bay of Islands.The Waipuakakahu Stream joins the Waiotu River at Waiotu on the Kawakawa-Whangarei Road, 17 miles north of Whangarei. The date April 1843 appears on a specimen of Lomaria fluviatilis (WELT p.3320) and the locality also occurs in the list of 30 July 1844. 
 *Te Waipukurau. The modern town of Waipukurau on the Tukituki in southern Hawke’s Bay. 22-23 Apr, 20-21 Oct 45; 7-8 Apr, 25-30 Jun, 3-5 Oct 46; 9-12 Jan, 1-2 & 25-26 Mar, 11-13 Sep, 25-27 Nov 47; 25-28 Mar, 23-26 Sep 48; 9-12 Mar, 17-19 Nov 49; 11-12 Apr, 19-21 Nov 50; 24-27 May, 30-31 Oct 51; 13-16 Mar 52. 
 Waipupu. Waipupu Stream is south of the Whareama River and about two miles north of Riversdale Beach, Wairarapa coast. 14 Mar 45; 24 Feb, 4 Sep 46; 11 May, 14 Oct 47; 3 Nov 48; 27-28 Apr 49; 14-15 Mar 50; 8-10 Apr 51; 15-17 Apr 52. 
-Waipureku. Bagnall & Petersen (p. 237) show Waipureku between the Ngaruroro and Tukituki River mouths. 26 Feb 51. 
-*Wairarapa Bay = Palliser Bay. 
+Waipureku. Bagnall & Petersen ( p. 237) show Waipureku between the Ngaruroro and Tukituki River mouths. 26 Feb 51. 
+*Wairarapa Bay (Palliser Bay). 
 Wairarapa Lagoon. It is clear that Colenso is referring only to the present Lake Onoke. His usual routes took him to the east or north of Lake Wairarapa and he appears never to have reached its shores. 2 Apr 45; 4-6 Mar 46; 2 Apr 49. 
 *Wairarapa Valley. Colenso includes the whole catchment of the Ruamahanga River from Mt Bruce to Palliser Bay. 1-9 Apr, 30 Oct-6 Nov 45; 17-24 Mar, 16-23 Sep 46; 7-15 Apr, 5-15 Nov 47; 11-19 Apr, 13-20 Nov 48; 22-30 Mar 49; 19 Mar-1 Apr 50; 19 Apr-12 May 51; 25 Mar-6 Apr 52. 
-*Te Wairere, “A very high hill.” The Wairere track was a well-known route across the Kaimai Ranges from Tauranga to Matamata. Some details of the track are given by Vennell (1969). The Wairere Falls are on the western side of the ridge. They are marked, together with the hill and the Ariki Falls further south, on Arrowsmith’s 1850 map. 20 Jan 42; (27 Jan 44: not mentioned in the Journal.)
-Te Wairo, “Our old potatoe plantation.” Between the Kaiwaka River and Tarawera. This would appear to have been on or near the Mohaka River, the usual last stop before Tarawera. 24-25 Jan 49. 
-Wairoa. The modern town of Wairoa in Northern Hawke’s Bay, although Colenso is probably referring to the river. He refers to the village as Uruhou (q.v.) 31 Jul-2 Aug 45. 
+*Te Wairere, A very high hill. The Wairere track was a well-known route across the Kaimai Ranges from Tauranga to Matamata. Some details of the track are given by Vennell (1969). The Wairere Falls are on the western side of the ridge. They are marked, together with the hill and the Ariki Falls further south, on Arrowsmith’s 1850 map. 20 Jan 42; (27 Jan 44 - not mentioned in the Journal).
+Te Wairo, Our old potatoe plantation. Between the Kaiwaka River and Tarawera. This would appear to have been on or near the Mohaka River, the usual last stop before Tarawera. 24-25 Jan 49. 
+Wairoa. The modern town of Wairoa in Northern Hawke’s Bay, although Colenso is probably referring to the river. He refers to the village as Uruhou (q.v.). 31 Jul-2 Aug 45. 
 *Wairoa River. A major river of Northern Hawke’s Bay. 15-18 Dec 43. 
 Wairoa River, Kaipara. Enters the northern arm of Kaipara Harbour. 10-11 Feb 44. 
 *Wairua River. The eastern branch of the Wairoa River, Northland. 23-25 Feb 36; Oct 42; 12 Feb 44. 
-Wairua, “On a small river.” This was inland from Helena Bay, Whangaruru Harbour but has not been located. It is evidently not associated with the Wairua River of the previous entry. 17-18 Feb 36. 
+Wairua, On a small river. This was inland from Helena Bay, Whangaruru Harbour but has not been located. It is evidently not associated with the Wairua River of the previous entry. 17-18 Feb 36. 
 Waitaatamakopiri. Not located. 
 Waitahunui River. The Waitahanui River flows into Lake Taupo on the eastern shore north of Te Kohaiakahu Point. 4 Dec 49. 
 *Waitangi, Bay of Islands. The famous Treaty site opposite Russell. Colenso records numerous visits between 1835 and 1840. 
 *Waitangi Mission Station, Ahuriri; Waitangi, Hawke’s Bay. This was located between the present mouths of the Tutaekuri and Ngaruroro Rivers although the river system was different in Colenso’s time (see Bagnall & Petersen, p.237). A New Zealand Historic Places Trust monument beside the Ngaruroro Bridge north of Clive commemorates the station although the actual site was nearer the sea. Colenso’s residence began on 30 December 1844. 
 *Waitangi River, Hawke’s Bay. Flowed south following the coast of Hawke Bay to enter the sea immediately north of the Ngaruroro River. It now flows into the Tutaekuri as a result of the latter’s change of course (see Bagnall & Petersen, p.237). The Mission Station was between the Waitangi and the Ngaruroro. 
-*Waitanoa. “A pa south of the Tutaekuri, to the south-east of the present Allen Road.” (Bagnall & Petersen, p.194n). 8 Jan 45; 28 Jan 47; 20 Jun 49. 
+*Waitanoa. A pa south of the Tutaekuri, to the south-east of the present Allen Road. (Bagnall & Petersen, p.194n). 8 Jan 45; 28 Jan 47; 20 Jun 49. 
 Te Ẁaiti. See Te Ẁaiiti. 
-Waitutuma, “A small stream.” The Waitetuna Stream rises on Mt Barton, Aorangi Mountains, and reaches the coast about three miles east of Cape Palliser. 4-5 May 47. 
+Waitutuma, A small stream. The Waitetuna Stream rises on Mt Barton, Aorangi Mountains, and reaches the coast about three miles east of Cape Palliser. 4-5 May 47. 
 Waiwetu. Waiwhetu, a suburb of Lower Hutt. 18 May 48. 
 Te Ẁakaki. Whakaki, on the main road east of Wairoa, northern Hawke’s Bay. 2-4 Aug 45. 
-Wakahau. Not located but “about 6 miles” from Otaika, Whangarei. 13 Dec 39. 
+Wakahau. Not located but about 6 miles from Otaika, Whangarei. 13 Dec 39. 
 Ẁakamarino. Whakamarino was on the site of present artificial Lake Whakamarino at Tuai, below Waikaremoana. 23-24 Dec 41. 
-Ẁakaraunuiataẁake, “A potatoe plantation; Ẁakaraunuiotawake.” This was on the coast between the Owahanga and Mataikona Rivers on the Wairarapa coast. On the last visit, Colenso notes it as “now growing into a village”, which, from earlier references, suggests that it had declined to a plantation before again being inhabited. 11-12 Mar, 15 Apr 45; 19 Feb, 28-29 Aug 46. 
+Ẁakaraunuiataẁake, A potatoe plantation; Ẁakaraunuiotawake. This was on the coast between the Owahanga and Mataikona Rivers on the Wairarapa coast. On the last visit, Colenso notes it as now growing into a village, which, from earlier references, suggests that it had declined to a plantation before again being inhabited. 11-12 Mar, 15 Apr 45; 19 Feb, 28-29 Aug 46. 
 *Ẁakaruatapu. Whakaruatapu Stream flows west of Matamau to join the Matamau Stream to the south of the township in southern Hawke’s Bay Province. Te Ẁakatakapau. Described as one mile from Waitanoa and two miles from Te Awatoto, Hawke’s Bay, but not mentioned by Bagnall & Petersen or by Buchanan. 28 Jan 47. 
 Ẁakataki. The Whakataki River enters the sea just north of Castle Point. The village of Waiorongo was near its mouth, and it is uncertain whether Colenso used alternative names for the same village or whether they were distinct places. 11 Apr 45; 1-2 Jun 48; 7-8 Apr 51. 
 Wakatane, Bay of Plenty Modern Whakatane. 
 *Ẁakatane River. The Whakatane River, Bay of Plenty. Jan 42; 29 Dec 43; 8 Jan 44. 
-Ẁakatomotomo, “A potatoe Plantation.” Near the Turanganui River, Wairarapa. 16 Sep 46; 24 May 48. 
+Ẁakatomotomo, A potatoe Plantation. Near the Turanganui River, Wairarapa. 16 Sep 46; 24 May 48. 
 Ẁakatu. On the Ngaruroro River close to the confluence with Karamu Creek. 21-22 May 49. 
-Wakaurekau River. “On the following day (7th Jan, 1848) they left Te Awarua, but wind and rain halted them on the banks of the Whakarekou stream…” (Bagnall & Petersen, p.269), i.e. a stream on the western side of the Ruahine Range probably near the base of the Mokai Patea ridge. No such stream is marked on modern maps. 
+Wakaurekau River. On the following day (7th Jan, 1848) they left Te Awarua, but wind and rain halted them on the banks of the Whakarekou stream… (Bagnall & Petersen, p.269), (a stream on the western side of the Ruahine Range probably near the base of the Mokai Patea ridge). No such stream is marked on modern maps. 
 Ẁakaurekou River. The Whakarekou River rises below Maroparea and Remutupo on the main Ruahine ridge and flows northwest to join the Rangitikei upstream from Awarua. 7-8 Jan 48. 
 Ẁakauruhanga near Te Unuunu. To the north of Flat Point, Wairarapa Coast (Bagnall & Petersen, p.218). 10-11 Apr 51; 14 Apr 52. 
 *Wakawitira. Whakawhitira on the Waiapu River, East Cape, about 10 miles from the mouth. 18-19 Jan 38; 29 Nov-1 Dec 41. 
@@ -687,9 +675,9 @@ Whangaehu River, a tributary of the Ruamahanga, the confluence being south of Ma
 Wangai. The Whangae River enters the Kawakawa River near the mouth on the west side. The locality of Whangae is inland considerably to the west, beyond the watershed of the river. Colenso gives several visits between 1835 and 1840, and is presumably referring to the river or to a village near its mouth. 
 Wangaihu see Wangaehu. 
 *Wangaiti River, near Cape Turnagain. This name appears in the list of July 1846 but is not mentioned in the Journal and has not been located. 
-Ẁangaiẁakarere, “A small village.”Possibly to be identified with Whangaimoana, the stream which flows northwest parallel to the coast to reach Palliser Bay about two miles east of Lake Onoke. 17 Mar 46. 
+Ẁangaiẁakarere, A small village.Possibly to be identified with Whangaimoana, the stream which flows northwest parallel to the coast to reach Palliser Bay about two miles east of Lake Onoke. 17 Mar 46. 
 *Wangape. Whangape on the harbour of the same name between Herekino and Hokianga Harbours, to the south of the Ninety Mile Beach, Northland. 23-25 Mar 39. 
-Wangara, “A bold jutting promontory.”Whangara is on the coast a few miles south of Gable End Foreland. 26 Jan 38. 
+Wangara, A bold jutting promontory.Whangara is on the coast a few miles south of Gable End Foreland. 26 Jan 38. 
 Ẁangarei. Modern Whangarei, but, as in other instances, it is not clear whether Colenso refers to a settlement or a district. Oct 41; Oct 42. 
 *Wangarei Bay. Whangarei Harbour. 8-9 Dec 39; 28-30 Sep 41; Oct 42. 
 Wangaroa Harbour. Whangaroa Harbour, the deep inlet between Doubtless Bay and Bay of Islands. 9-10 Apr 39. 
@@ -698,28 +686,27 @@ Wangaroa River, Wangaruru District. No longer so named. Colenso seems to mean th
 Wangaruru. On the east side of Whangaruru Harbour, south of the Bay of Islands. 15-16 Apr 35; 10-13 Feb 36; 20 & 24-25 Jun, 26-30 Sep, 1 Oct 39; 17 Aug, 18 Sep 41. 
 *Wangaruru Bay. Whangaruru Harbour, south of Bay of Islands. The upper reaches of the harbour, known as Whangaruru Inlet, are referred to by Colenso as the Wangaroa River. For dates see Wangaruru. 
 Te Ẁarau Hill. Te Wharau is a ridge between the Whakatane and Waikare Rivers, not far from the junction. 13 Jan 44. Te Ẁarau. On the Wairoa River, upstream from Dargaville. 11 Feb 44. 
-*Ẁaraurangi. “On the flat a quarter of a mile south of Glenburn Station homestead, behind Horewai Point, by the karaka grove.” (Bagnall & Petersen, p.219n) i.e. to the south of Flat Point, Wairarapa coast. 15-18 Mar, 24 Nov 45; 25 Feb, 7-8 Sep 46; 10 May, 16 Oct 47; 4 Nov 48; 26-27 Apr 49; 15-16 Mar 50; 11-12 Apr 51; 14 Apr 52. 
-Waraurangi, Coast, Waraurangi, E. Coast. Bagnall & Petersen (p. 213) describe it as being on the south side of the long shallow bay south of Flat Point, on the Wairarapa coast. There is a Māori cemetery at the mouth of the Waikekino Stream. Bagnall and Petersen’s map (p. 218) shows it slightly south of this bay, on the site of the Glenburn station. 
+*Ẁaraurangi. On the flat a quarter of a mile south of Glenburn Station homestead, behind Horewai Point, by the karaka grove. (Bagnall & Petersen, p.219n) (to the south of Flat Point, Wairarapa coast). 15-18 Mar, 24 Nov 45; 25 Feb, 7-8 Sep 46; 10 May, 16 Oct 47; 4 Nov 48; 26-27 Apr 49; 15-16 Mar 50; 11-12 Apr 51; 14 Apr 52. 
+Waraurangi Coast, Waraurangi, E. Coast. Bagnall & Petersen ( p. 213) describe it as being on the south side of the long shallow bay south of Flat Point, on the Wairarapa coast. There is a Māori cemetery at the mouth of the Waikekino Stream. Bagnall and Petersen’s map ( p. 218) shows it slightly south of this bay, on the site of the Glenburn station. 
 *Ẁareama. 1. The Whareama River enters the sea about eight miles north of Uruti Point on the Wairarapa coast. Colenso seems to have so named an inland village or place. 10 Apr, 29-30 Oct 45. 2. Apparently a village on the coast, at the mouth of the river:24 Feb, 3-4 Sep 46; 11-12 May, 14 Oct 47; 31 May-1 Jun, 3 Nov 48; 28 Apr 49; 8 Apr 51. 
 *Warekahika. Wharekahika, Hick’s Bay, East Cape. 16 Jan 38; 22-23 Nov 41. 
-Te Ẁareohinekiri, “a sleeping-place a little below the top of the E. side of the (Ruahine) range.”25-26 Feb 52. 
+Te Ẁareohinekiri, a sleeping-place a little below the top of the E. side of the (Ruahine) range.25-26 Feb 52. 
 WareoraWhareora, east of Whangarei. 17-18 Dec 39; 4 Oct 41. 
-Warengarahu, “A romantically situated hamlet on the side of a hill” (between Opaoho and Kawakawa, Bay of Islands, but not located). 9 Feb 40; 21 Feb 41. 
-Ẁarepapa. The Wharepapa River enters Palliser Bay a mile or so to the west of Lake Onoke. 
-13 Mar 46. 
+Warengarahu, A romantically situated hamlet on the side of a hill (between Opaoho and Kawakawa, Bay of Islands, but not located). 9 Feb 40; 21 Feb 41. 
+Ẁarepapa. The Wharepapa River enters Palliser Bay a mile or so to the west of Lake Onoke. 13 Mar 46. 
 *Wareponga. Whareponga is on the coast a few miles north of Waipiro Bay, between East Cape and Poverty Bay. 22 Jan 38; 1-2 Dec 41. 
 Warerangi. Wharerangi is to the west of the old lagoon and opposite Napier. 21-23 Jun 47; 17 Oct 48; 31 Jan, 19-20 Jun 49; 15-16 Jan 50; 29 Jun-1 Jul 52. 
-Wareturere. “Wareturere was about four miles south-east of the site of the present town of Cambridge.” (Bagnall & Petersen, p.138n). 21-24 Jan 42. 
+Wareturere. Wareturere was about four miles south-east of the site of the present town of Cambridge. (Bagnall & Petersen, p.138n). 21-24 Jan 42. 
 Warewatukahakaha. The plantations of Orauta. 10 Nov 39. 
 Te Ẁataarakai. In the vicinity of Te Tamumu and Waipukurau but not located on modern maps nor mentioned by Buchanan. 25 Mar 48. 
-*Wataatamakopiri,Height above Kuripapango. Buchanan (p. 198) so identifies a feature now marked as Te Whata No. 2 (2544 feet alt.) to the east of Timahanga on the Taihape-Napier Road. The name does not appear in the Journal but on a cryptogam packet. The date would be 16 October 1851. 
+*Wataatamakopiri,Height above Kuripapango. Buchanan ( p. 198) so identifies a feature now marked as Te Whata No. 2 (2544 feet alt.) to the east of Timahanga on the Taihape-Napier Road. The name does not appear in the Journal but on a cryptogam packet. The date would be 16 October 1851. 
 *Ẁataroa. Whatarua is on the upper Mangaaruhe River at the junction of the Ohuka, Matakuhia and Mangarewarewa Roads, east of Waikaremoana. 23 Dec 41. 
 Watawata	On the immediate banks of the Waipa. Not named by Colenso. 27 Jan 42. 
 *Watuma. Whatuma Lake is a mile or so southwest of Waipukurau. Previously spelt Hatuma. The name appears on a few specimen labels. 
 *Te Ẁau. Te Whau, on the north shore of Manukau Harbour, at the western end of Blockhouse Bay. 4 Feb 42; 5-6 Feb 44. 
 *Wellington. The city on Wellington Harbour – at the southern end of the North Island. In Colenso’s time it would have been confined to the Te Aro flat area on the southern shore of the harbour at Lambton or Inner Harbour. 26-30 Mar, 11-13 Nov 45; 9-11 Mar 46; 21-22 & 26-27 Apr, 28 Oct-2 Nov 47; 3-5, 9-13 & 15-17 May 48; 9-14 Apr 49. 
-Te Wera-a-te-Atua. “… in the vicinity of the present-day Maungatautari pa” (Bagnall & Petersen, p.138n). i.e. near Cambridge. 23 Jan 42. 
+Te Wera-a-te-Atua. … in the vicinity of the present-day Maungatautari pa (Bagnall & Petersen, p.138n). (near Cambridge). 23 Jan 42. 
 Te Werahi River. This river reaches Sandy Bay between Cape Reinga and Cape Maria van Dieman. 30 Mar-1 Apr 39. 
 Whariti Whariti or Wharite is a peak in the southern Ruahine Range, six miles north of Woodville. 
 *Ẁirinake river; Wirinaki. The Whirinaki is a tributary of the Rangitaiki River. Colenso does not name the river at Te Whaiti, recognizing it only lower down near the Rangitaiki. 4-6 Jan 42; 30 Dec 43; 3-4 Jan 44. 
-*Te Ẁiti. “The Te Whiti clearing, a mile across, began just beyond the crossing of the Manawatu, some three miles from the present Takapau” (Bagnall & Petersen, p.233n). 6-7 Apr, 2-3 Oct 46; 26-27 Mar 47; 28-29 Mar 48; 12-13 Mar 49; 23-24 May 51; 16-17 Mar 52. 
+*Te Ẁiti. The Te Whiti clearing, a mile across, began just beyond the crossing of the Manawatu, some three miles from the present Takapau (Bagnall & Petersen, p.233n). 6-7 Apr, 2-3 Oct 46; 26-27 Mar 47; 28-29 Mar 48; 12-13 Mar 49; 23-24 May 51; 16-17 Mar 52. 


### PR DESCRIPTION
Cleaned up placenames.txt to finx small issues.  Some lines where also split where they should not have been.

Added a tab separated file PlaceNames.csv which splits the data into 4 rough fields: PlaceNames, Primary Description, Secondary Description, Date.
Also removed all lines which are simply references to other lines, eg Barrier Island. see Aotea.    Aotea already references Barrier Island.  (at the request of Jamie)

Bracketed words in the Place Name column are alternative names.
